### PR TITLE
ENH: this updates the latex backend to include cjk

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,8 @@ jobs:
             latexmk                   \
             xindy                     \
             dvipng                    \
-            cm-super
+            cm-super                  \
+            latex-cjk-all
       - name: Display Conda Environment Versions
         shell: bash -l {0}
         run: conda list


### PR DESCRIPTION
This update the latex backend to include support for `cjk`

fixes #13 