### PR TITLE
MAINT: upgrade anaconda=2025.06 and python=3.13

### DIFF
--- a/.github/workflows/_future/cache-windows.yml
+++ b/.github/workflows/_future/cache-windows.yml
@@ -17,7 +17,7 @@ jobs:
           auto-update-conda: true
           auto-activate-base: true
           miniconda-version: 'latest'
-          python-version: "3.12"
+          python-version: "3.13"
           environment-file: environment.yml
           activate-environment: quantecon
       - name: Build HTML

--- a/.github/workflows/_future/ci-cn.yml
+++ b/.github/workflows/_future/ci-cn.yml
@@ -12,7 +12,7 @@ jobs:
           auto-update-conda: true
           auto-activate-base: true
           miniconda-version: 'latest'
-          python-version: "3.12"
+          python-version: "3.13"
           environment-file: environment-cn.yml
           activate-environment: quantecon
       - name: Graphics Support

--- a/.github/workflows/_future/ci-windows.yml
+++ b/.github/workflows/_future/ci-windows.yml
@@ -12,7 +12,7 @@ jobs:
           auto-update-conda: true
           auto-activate-base: true
           miniconda-version: 'latest'
-          python-version: "3.12"
+          python-version: "3.13"
           environment-file: environment.yml
           activate-environment: quantecon
       - name: Download "build" folder (cache)

--- a/.github/workflows/_future/linkcheck.yml
+++ b/.github/workflows/_future/linkcheck.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-latest"]
-        python-version: ["3.12"]
+        python-version: ["3.13"]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -23,7 +23,7 @@ jobs:
           auto-update-conda: true
           auto-activate-base: true
           miniconda-version: 'latest'
-          python-version: "3.12"
+          python-version: "3.13"
           environment-file: environment.yml
           activate-environment: quantecon
       - name: Download "build" folder (cache)

--- a/.github/workflows/cache.yml
+++ b/.github/workflows/cache.yml
@@ -16,7 +16,7 @@ jobs:
           auto-update-conda: true
           auto-activate-base: true
           miniconda-version: 'latest'
-          python-version: "3.12"
+          python-version: "3.13"
           environment-file: environment.yml
           activate-environment: quantecon
       - name: graphviz Support # TODO: required?

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
           auto-update-conda: true
           auto-activate-base: true
           miniconda-version: 'latest'
-          python-version: "3.12"
+          python-version: "3.13"
           environment-file: environment.yml
           activate-environment: quantecon
       - name: Graphics Support #TODO: Review if graphviz is needed

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,7 +16,7 @@ jobs:
           auto-update-conda: true
           auto-activate-base: true
           miniconda-version: 'latest'
-          python-version: "3.12"
+          python-version: "3.13"
           environment-file: environment.yml
           activate-environment: quantecon
       - name: Install latex dependencies

--- a/environment-cn.yml
+++ b/environment-cn.yml
@@ -3,18 +3,18 @@ channels:
   - default
   - conda-forge
 dependencies:
-  - python=3.12
-  - anaconda=2024.10
+  - python=3.13
+  - anaconda=2025.06
   - pip
   - pip:
-    - jupyter-book==1.0.3
-    - quantecon-book-theme==0.8.2
-    - sphinx-tojupyter==0.3.0
+    - jupyter-book==1.0.4post1
+    - quantecon-book-theme==0.9.2
+    - sphinx-tojupyter==0.3.1
     - sphinxext-rediraffe==0.2.7
     - sphinx_reredirects==0.1.4
     - sphinx-exercise==1.0.1
-    - sphinx-proof==0.2.0
+    - sphinx-proof==0.2.1
     - ghp-import==1.1.0
-    - sphinxcontrib-youtube==1.3.0 #Version 1.3.0 is required as quantecon-book-theme is only compatible with sphinx<=5
+    - sphinxcontrib-youtube==1.4.1 #Version 1.3.0 is required as quantecon-book-theme is only compatible with sphinx<=5
     - sphinx-togglebutton==0.3.2
     - --index-url https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple

--- a/environment.yml
+++ b/environment.yml
@@ -2,18 +2,16 @@ name: quantecon
 channels:
   - default
 dependencies:
-  - python=3.12
-  - anaconda=2024.10
+  - python=3.13
+  - anaconda=2025.06
   - pip
   - pip:
-    - jupyter-book==1.0.3
-    - quantecon-book-theme==0.8.2
-    - sphinx-tojupyter==0.3.0
+    - jupyter-book==1.0.4post1
+    - quantecon-book-theme==0.9.2
+    - sphinx-tojupyter==0.3.1
     - sphinxext-rediraffe==0.2.7
-    - sphinx-reredirects==0.1.4
     - sphinx-exercise==1.0.1
-    - sphinx-proof==0.2.0
-    - ghp-import==1.1.0
-    - sphinxcontrib-youtube==1.3.0 #Version 1.3.0 is required as quantecon-book-theme is only compatible with sphinx<=5
+    - sphinx-proof==0.2.1
+    - sphinxcontrib-youtube==1.4.1
     - sphinx-togglebutton==0.3.2
-
+    - sphinx-reredirects==0.1.4


### PR DESCRIPTION
Hi @mmcky and @nisha617,

@nisha617 reported import error below:

<img width="3801" height="1985" alt="image" src="https://github.com/user-attachments/assets/10f39d2b-e420-47ef-9f72-d1da626dec1a" />


This PR updates the software stack to use `numpy==2.x`. It fixes warnings that I can find.

Please let me know if you see more errors/warnings or we can merge it!