### PR TITLE
MAINT: Add HTML archive to release assets (Phase 1)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -72,6 +72,32 @@ jobs:
         shell: bash -l {0}
         run: |
           jb build lectures --path-output ./
+      # Create HTML archive for release assets
+      - name: Create HTML archive
+        shell: bash -l {0}
+        run: |
+          tar -czf lecture-python-zh-cn-html-${{ github.ref_name }}.tar.gz -C _build/html .
+          sha256sum lecture-python-zh-cn-html-${{ github.ref_name }}.tar.gz > html-checksum.txt
+          
+          # Create metadata manifest
+          cat > html-manifest.json << EOF
+          {
+            "tag": "${{ github.ref_name }}",
+            "commit": "${{ github.sha }}",
+            "timestamp": "$(date -Iseconds)",
+            "size_mb": $(du -sm _build/html | cut -f1),
+            "file_count": $(find _build/html -type f | wc -l)
+          }
+          EOF
+      - name: Upload archives to release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            lecture-python-zh-cn-html-${{ github.ref_name }}.tar.gz
+            html-checksum.txt
+            html-manifest.json
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Deploy to Netlify
         uses: nwtgck/actions-netlify@v3.0
         with:


### PR DESCRIPTION
## Overview

This PR implements Phase 1 of the publishing workflow upgrade as tracked in [QuantEcon/meta#253](https://github.com/QuantEcon/meta/issues/253).

## Changes

Adds the following steps to `publish.yml` after the HTML build:

1. **Create HTML archive** - Compresses `_build/html/` into `lecture-python-zh-cn-html-{tag}.tar.gz`
2. **Generate checksum** - Creates SHA256 hash for integrity verification (`html-checksum.txt`)
3. **Create manifest** - Generates metadata file with build information (`html-manifest.json`)
4. **Upload to release** - Attaches all three files to the GitHub release using `softprops/action-gh-release@v2`

## Release Assets Created

Each `publish-*` tag will now include:

- 📦 `lecture-python-zh-cn-html-{tag}.tar.gz` - Full HTML site archive
- 🔐 `html-checksum.txt` - SHA256 verification file
- 📋 `html-manifest.json` - Build metadata (tag, commit, timestamp, size, file count)

## Testing

After merging, test with a `publish-test-*` tag to verify:

1. Workflow completes successfully
2. Three HTML assets are attached to release
3. Archive can be downloaded and extracted
4. Checksum verification works: `sha256sum -c html-checksum.txt`