### PR TITLE
Add translation review and rebase workflows (Phase 0 Track B)

### DIFF
--- a/.github/workflows/rebase-translations.yml
+++ b/.github/workflows/rebase-translations.yml
@@ -1,0 +1,41 @@
+# Rebase Translation PRs
+#
+# Install this workflow in the TARGET (translated) repository.
+# When a translation-sync PR is merged, this workflow automatically
+# rebases other open translation-sync PRs against the updated main branch.
+#
+# This eliminates merge conflicts caused by multiple upstream PRs
+# modifying the same files. See: https://github.com/QuantEcon/action-translation/issues/63
+#
+# Place this file at: .github/workflows/rebase-translations.yml
+
+name: Rebase Translation PRs
+
+on:
+  pull_request:
+    types: [closed]
+
+jobs:
+  rebase:
+    # Only run when a translation-sync PR is merged
+    if: >
+      github.event.pull_request.merged == true &&
+      startsWith(github.event.pull_request.head.ref, 'translation-sync-')
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
+      pull-requests: write
+
+    # Prevent concurrent rebases from overlapping
+    concurrency:
+      group: rebase-translations
+      cancel-in-progress: false
+
+    steps:
+      - name: Rebase open translation PRs
+        uses: QuantEcon/action-translation@v0
+        with:
+          mode: rebase
+          anthropic-api-key: ${{ secrets.ANTHROPIC_API_KEY }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/review-translations.yml
+++ b/.github/workflows/review-translations.yml
@@ -1,0 +1,49 @@
+# Review Translations — Quality check on translation PRs
+# When a PR is opened/updated that carries the 'action-translation' label,
+# this workflow runs a quality review and posts a comment.
+#
+# Mirrors the upstream template in action-translation
+# docs/user/tutorials/connect-existing.md — keep it in step with that.
+name: Review Translations
+
+on:
+  pull_request:
+    types: [opened, synchronize, labeled, reopened]
+
+jobs:
+  review:
+    # Ignore `labeled` events for every other label: a sync adds its labels in a single
+    # addLabels call, but GitHub emits one `labeled` event per label, and each would
+    # otherwise start a full (billed) review of the same diff.
+    if: >
+      contains(github.event.pull_request.labels.*.name, 'action-translation') &&
+      (github.event.action != 'labeled' || github.event.label.name == 'action-translation')
+    runs-on: ubuntu-latest
+
+    # v0.17.0's review dedupe deletes superseded comments, which needs pull-requests: write.
+    permissions:
+      contents: read
+      pull-requests: write
+
+    # One review per PR — supersede an in-flight review instead of running both.
+    # Job-level (not workflow-level) on purpose: the group is entered only after the `if`
+    # above has passed, so a `labeled` event for 'automated' skips out without cancelling
+    # the real review. At workflow level it would cancel first and skip second, leaving none.
+    concurrency:
+      group: review-translations-${{ github.event.pull_request.number }}
+      cancel-in-progress: true
+
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 2
+
+      - uses: QuantEcon/action-translation@v0
+        with:
+          mode: review
+          source-repo: QuantEcon/lecture-python.myst
+          source-language: en
+          target-language: zh-cn
+          docs-folder: lectures
+          anthropic-api-key: ${{ secrets.ANTHROPIC_API_KEY }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Part of QuantEcon/lecture-python.myst#947. Adds `review-translations.yml` and `rebase-translations.yml`, copied from lecture-intro.zh-cn's Track A wiring (fr-pattern review guards, v0.17.0 review dedupe, job-level concurrency) with source-repo pointed at QuantEcon/lecture-python.myst.

**Blocked on a secret**: the ANTHROPIC_API_KEY org secret is not yet visible to this repo (QUANTECON_SERVICES_PAT is). Extending it needs org admin — until then the review/rebase jobs will fail at the API-key step.

**Known limitation**: the review workflow reviews resync PRs only once a release containing action-translation#108 ships and `@v0` moves — the current v0.17.0 `@v0` still lacks #104's metadata fallback, so this wave's resync PRs get their review from the local sweep instead (see the wave report).

🤖 Generated with [Claude Code](https://claude.com/claude-code)