### PR TITLE
[action-translation] resync: navy_captain.md

### DIFF
--- a/.translate/state/navy_captain.md.yml
+++ b/.translate/state/navy_captain.md.yml
@@ -1,0 +1,6 @@
+source-sha: 36bc72ea8fe852f84c63534cd0530c549c43c5cc
+synced-at: "2026-07-18"
+model: claude-sonnet-5
+mode: RESYNC
+section-count: 9
+tool-version: 0.17.0

--- a/lectures/navy_captain.md
+++ b/lectures/navy_captain.md
@@ -924,7 +924,7 @@ plt.legend()
 
 plt.xlabel('t')
 plt.ylabel('n')
-plt.title('目标值函数 $V(\pi)$')
+plt.title('时间的无条件分布')
 
 plt.show()
 ```

--- a/lectures/navy_captain.md
+++ b/lectures/navy_captain.md
@@ -7,6 +7,18 @@ kernelspec:
   display_name: Python 3
   language: python
   name: python3
+translation:
+  title: 贝叶斯与频率主义决策规则的比较
+  headings:
+    Overview: 概述
+    Setup: 设置
+    Frequentist Decision Rule: 频率主义决策规则
+    Bayesian Decision Rule: 贝叶斯决策规则
+    Was the Navy Captain’s Hunch Correct?: 海军上尉的直觉是否正确？
+    More Details: 更多细节
+    Distribution of Bayesian Decision Rule’s Time to Decide: 贝叶斯决策规则的决策时间分布
+    Probability of Making Correct Decision: 做出正确决策的概率
+    Distribution of Likelihood Ratios at Neyman-Pearson's $t$: Neyman-Pearson的$t$处的似然比分布
 ---
 
 (bayesian_vs_frequentist__v1)=
@@ -44,42 +56,46 @@ from scipy.optimize import minimize
 本讲座延续了以下讲座中提出的观点：
 
 * {doc}`令米尔顿·弗里德曼困惑的问题 <wald_friedman>`
+* {doc}`弗里德曼与瓦尔德问题的贝叶斯表述 <wald_friedman_2>`
 * {doc}`可交换性和贝叶斯更新 <exchangeable>`
 * {doc}`似然比过程 <likelihood_ratio_process>`
 
-在{doc}`令米尔顿·弗里德曼困惑的问题 <wald_friedman>`中，我们描述了二战期间一位海军上尉向米尔顿·弗里德曼提出的问题。
+{doc}`令米尔顿·弗里德曼困惑的问题 <wald_friedman>`描述了二战期间一位海军上尉向米尔顿·弗里德曼提出的问题。
 
-海军要求上尉使用一个质量控制决策规则，但上尉怀疑可能存在更好的规则。
+海军告诉这位上尉要使用一个质量控制决策规则。
 
-（海军命令上尉使用一个**频率主义决策规则**的实例。）
+具体来说，海军命令上尉使用一个**频率主义决策规则**的实例。
+
+上尉怀疑这个规则是否是一个好规则。
 
 米尔顿·弗里德曼认识到上尉的推测提出了一个具有挑战性的统计问题，他和哥伦比亚大学美国政府统计研究小组的其他成员随后试图解决这个问题。
 
-该小组的成员之一，伟大的数学家亚伯拉罕·瓦尔德很快就解决了这个问题。
+该小组的成员之一，伟大的数学家和经济学家亚伯拉罕·瓦尔德很快就解决了这个问题。
 
-用贝叶斯统计中的一些思想来阐述这个问题是一个很好的方法,这些思想我们在讲座{doc}`可交换性和贝叶斯更新 <exchangeable>`和讲座{doc}`似然比过程 <likelihood_ratio_process>`中有所描述,后者阐述了贝叶斯更新和似然比过程之间的联系。
+阐述这个问题的一个好方法是使用一些贝叶斯统计中的思想，这些思想我们在讲座{doc}`可交换性和贝叶斯更新 <exchangeable>`和讲座{doc}`似然比过程 <likelihood_ratio_process>`中有所描述，后者阐述了贝叶斯更新和似然比过程之间的联系。
 
-本讲座使用Python生成模拟,评估在海军上尉决策问题的一个实例中,**频率主义**和**贝叶斯**决策规则下的期望损失。
+本讲座使用Python生成模拟，评估在海军上尉所质疑的Neyman-Pearson**频率主义**程序，以及{doc}`弗里德曼与瓦尔德问题的贝叶斯表述 <wald_friedman_2>`中描述的**贝叶斯**决策规则下的预期损失。
 
-这些模拟验证了海军上尉的直觉,即存在一个比海军命令他使用的规则更好的规则。
+这些模拟证实了海军上尉的直觉，即存在一个比海军命令他使用的Neyman-Pearson似然比检验更好的规则。
 
 ## 设置
 
-为了形式化米尔顿·弗里德曼和艾伦·沃利斯交给亚伯拉罕·瓦尔德的海军上尉问题,我们考虑一个包含以下部分的设定。
+为了形式化困扰海军上尉的问题，我们考虑一个包含以下部分的设定。
 
 - 每个时期决策者都会抽取一个非负随机变量
-
-决策者从一个他并不完全理解的概率分布中获得$Z$。他知道可能存在两种概率分布，$f_{0}$和$f_{1}$，并且无论是哪种分布都会随时间保持不变。决策者认为在时间开始之前，自然界一次性地选择了$f_{0}$或$f_1$，且选择$f_0$的概率为$\pi^{*}$。
+  $Z$。他知道可能存在两种概率分布，$f_{0}$和$f_{1}$，并且无论是哪种分布都会随时间保持不变。决策者认为在时间开始之前，自然界一次性地选择了$f_{0}$或$f_1$，且选择$f_0$的概率为$\pi^{*}$。
 - 决策者从自然界选择的分布中观察到样本$\left\{ z_{i}\right\} _{i=0}^{t}$。
 
-决策者想要确定究竟是哪个分布在支配$Z$，并且担心两种类型的错误及其带来的损失。
+决策者想要确定究竟是哪个分布在支配$Z$。
+
+他担心两种类型的错误以及它们将给他带来的损失。
 
 - **第一类错误**造成的损失$\bar L_{1}$，即当实际分布为$f=f_{0}$时却判定$f=f_{1}$
 - **第二类错误**造成的损失$\bar L_{0}$，即当实际分布为$f=f_{1}$时却判定$f=f_{0}$
 
-决策者需要支付成本$c$来获取另一个$z$
+决策者需要支付成本$c$来获取另一个$z$。
 
-我们主要借鉴了quantecon讲座中{doc}`一个让弗里德曼困惑的问题 <wald_friedman>`的参数，不过我们将$\bar L_{0}$和$\bar L_{1}$都从$25$增加到了$100$，以鼓励频率学派的海军上尉在做决定前进行更多次抽样。
+我们主要借鉴了quantecon讲座{doc}`弗里德曼与瓦尔德问题的贝叶斯表述 <wald_friedman_2>`中的参数，不过我们将$\bar L_{0}$和$\bar L_{1}$都从$25$增加到了$100$，以鼓励贝叶斯决策规则在做决定前进行更多次抽样。
 
 我们将每次额外抽样的成本$c$设为$1.25$。
 
@@ -184,26 +200,31 @@ plt.show()
 
 ## 频率主义决策规则
 
-海军要求舰长使用频率主义决策规则。
+海军告诉上尉要使用Neyman-Pearson似然比决策规则。
 
-具体来说，海军给他一个决策规则，这个规则是海军通过使用频率主义统计理论来最小化预期损失函数而设计的。
+该决策规则的特征是由：
 
-该决策规则的特征是由样本量 $t$ 和与似然比相关的临界值 $d$ 来确定。
+ * 样本量 $t$，以及
+ * 似然比的临界值 $d$
 
-令 $L\left(z^{t}\right)=\prod_{i=0}^{t}\frac{f_{0}\left(z_{i}\right)}{f_{1}\left(z_{i}\right)}$ 为观察序列 $\left\{ z_{i}\right\} _{i=0}^{t}$ 的似然比。
+令
+$L\left(z^{t}\right)=\prod_{i=0}^{t}\frac{f_{0}\left(z_{i}\right)}{f_{1}\left(z_{i}\right)}$
+为观察序列 $\left\{ z_{i}\right\} _{i=0}^{t}$ 的似然比。
 
 与样本量 $t$ 相关的决策规则是：
 
 - 如果似然比大于 $d$，则判定 $f_0$ 是分布
+- 如果似然比小于 $d$，则判定 $f_1$ 是分布
 
-为了理解这个规则是如何设计的，让我们设定零假设和备择假设为：
+为此，我们想要计算使用这一规则所产生的预期损失，其中我们借用了{doc}`弗里德曼与瓦尔德问题的贝叶斯表述 <wald_friedman_2>`中的损失参数$\bar L_1$和$\bar L_2$。
 
-- 零假设：$H_{0}$：$f=f_{0}$
-- 备择假设 $H_{1}$：$f=f_{1}$
+令零假设和备择假设为
 
-在给定样本量 $t$ 和临界值 $d$ 的情况下，在模型中
+- 零假设：$H_{0}$：$f=f_{0}$，
+- 备择假设 $H_{1}$：$f=f_{1}$。
 
-如上所述，总损失的数学期望为
+在给定样本量 $t$ 和临界值 $d$ 的情况下，在上述模型下，
+总损失的数学期望为
 
 ```{math}
 :label: val1
@@ -228,15 +249,16 @@ $$
   当 $H_1$ 为真时却没有拒绝 $H_0$
 
 对于给定的样本量 $t$，$\left(PFA,PD\right)$ 对
-位于**接收者操作特征曲线**上，可以通过选择 $d$ 来
-唯一确定。
+位于**接收者操作特征曲线**上。
+  * 通过选择 $d$，我们为给定的 $t$ 选择曲线上的一个特定 $\left(PFA,PD\right)$ 对
 
 要查看一些接收者操作特征曲线，请参阅本课程
 {doc}`似然比过程 <likelihood_ratio_process>`。
 
 要数值求解 $\bar{V}_{fre}\left(t,d\right)$，我们首先
-
 模拟当$f_0$或$f_1$生成数据时的$z$序列。
+
+让我们绘制与$f_0$和$f_1$相关的经验分布（即直方图）。
 
 ```{code-cell} ipython3
 N = 10000
@@ -292,7 +314,7 @@ plt.title("接收者操作特征曲线")
 plt.show()
 ```
 
-我们的频率学派通过选择$\left(t,d\right)$来最小化方程{eq}`val1`中给出的预期总损失。
+我们可以通过选择 $\left(t,d\right)$ 来最小化方程{eq}`val1`中给出的预期总损失。
 
 这样做会得到预期损失
 
@@ -320,7 +342,7 @@ def V_fre_d_t(d, t, L0_arr, L1_arr, π_star, wf):
     PFA = np.sum(L0_arr[:, t-1] < d) / N
     PD = np.sum(L1_arr[:, t-1] < d) / N
 
-    V = π_star * PFA *wf. L1 + (1 - π_star) * (1 - PD) * wf.L0
+    V = π_star * PFA * wf.L1 + (1 - π_star) * (1 - PD) * wf.L0
 
     return V
 ```
@@ -344,7 +366,7 @@ def compute_V_fre(L0_arr, L1_arr, π_star, wf):
     T = L0_arr.shape[1]
 
     V_fre_arr = np.empty(T)
-    PFA_arr = np.empty(T) 
+    PFA_arr = np.empty(T)
     PD_arr = np.empty(T)
 
     for t in range(1, T+1):
@@ -361,7 +383,7 @@ def compute_V_fre(L0_arr, L1_arr, π_star, wf):
 V_fre_arr, PFA_arr, PD_arr = compute_V_fre(L0_arr, L1_arr, π_star, wf)
 
 plt.plot(range(T), V_fre_arr, label=r'$\min_{d} \overline{V}_{fre}(t,d)$')
-plt.xlabel('时间t')
+plt.xlabel('t')
 plt.title(r'$\pi^*=0.5$')
 plt.legend()
 plt.show()
@@ -371,10 +393,7 @@ plt.show()
 t_optimal = np.argmin(V_fre_arr) + 1
 ```
 
-```{code-cell} ipython3
-msg = f"上图表明，对t进行最小化告诉频率学家要抽取{t_optimal}个观测值然后做出决定。"
-print(msg)
-```
+上图说明了对$t$进行最小化如何告诉频率派要抽取$t_{\rm optimal}$个观测值然后做出决定。
 
 现在让我们改变 $\pi^{*}$ 的值，观察决策规则如何变化。
 
@@ -412,24 +431,24 @@ fig, axs = plt.subplots(1, 2, figsize=(14, 5))
 
 axs[0].plot(π_star_arr, t_optimal_arr)
 axs[0].set_xlabel(r'$\pi^*$')
-axs[0].set_title('optimal sample size given $\pi^*$')
+axs[0].set_title(r'给定$\pi^*$的最优样本量')
 
-axs[1].plot(π_star_arr, PFA_optimal_arr, label='$PFA^*(\pi^*)$')
-axs[1].plot(π_star_arr, PD_optimal_arr, label='$PD^*(\pi^*)$')
+axs[1].plot(π_star_arr, PFA_optimal_arr, label=r'$PFA^*(\pi^*)$')
+axs[1].plot(π_star_arr, PD_optimal_arr, label=r'$PD^*(\pi^*)$')
 axs[1].set_xlabel(r'$\pi^*$')
 axs[1].legend()
-axs[1].set_title('optimal PFA and PD given $\pi^*$')
+axs[1].set_title(r'给定$\pi^*$的最优PFA和PD')
 
 plt.show()
 ```
 
 ## 贝叶斯决策规则
 
-在{doc}`一个让米尔顿·弗里德曼困惑的问题 <wald_friedman>`中，我们了解到亚伯拉罕·瓦尔德如何证实了海军上尉的直觉，即存在一个更好的决策规则。
+在{doc}`令米尔顿·弗里德曼困惑的问题 <wald_friedman>`中，我们了解到亚伯拉罕·瓦尔德如何证实了海军上尉的直觉，即存在一个更好的决策规则。
 
-我们提出了一个贝叶斯程序，指导上尉通过比较他当前的贝叶斯后验概率$\pi$与两个临界概率$\alpha$和$\beta$来做出决策。
+在{doc}`弗里德曼与瓦尔德问题的贝叶斯表述 <wald_friedman_2>`中，我们提出了一个贝叶斯程序，该程序通过比较贝叶斯后验概率$\pi$与称为$A$和$B$的临界概率来做出决策。
 
-为了继续，我们从quantecon讲座{doc}`一个让米尔顿·弗里德曼困惑的问题 <wald_friedman>`中借用一些Python代码，用于计算$\alpha$和$\beta$。
+为了继续，我们从quantecon讲座{doc}`弗里德曼与瓦尔德问题的贝叶斯表述 <wald_friedman_2>`中借用一些Python代码，用于计算$A$和$B$的最优值。
 
 ```{code-cell} ipython3
 @jit(parallel=True)
@@ -512,18 +531,18 @@ def find_cutoff_rule(wf, h):
 
     # 通过将这些成本与贝尔曼方程的差值可以找到临界点
     # (J始终小于或等于p_c_i)
-    β = π_grid[np.searchsorted(
+    B = π_grid[np.searchsorted(
                               payoff_f1 - np.minimum(h, payoff_f0),
                               1e-10)
                - 1]
-    α = π_grid[np.searchsorted(
+    A = π_grid[np.searchsorted(
                               np.minimum(h, payoff_f1) - payoff_f0,
                               1e-10)
                - 1]
 
-    return (β, α)
+    return (B, A)
 
-β, α = find_cutoff_rule(wf, h_star)
+B, A = find_cutoff_rule(wf, h_star)
 cost_L0 = (1 - wf.π_grid) * wf.L0
 cost_L1 = wf.π_grid * wf.L1
 
@@ -536,11 +555,11 @@ ax.plot(wf.π_grid,
         np.amin(np.column_stack([h_star, cost_L0, cost_L1]),axis=1),
         lw=15, alpha=0.1, color='b', label='最小成本')
 
-ax.annotate(r"$\beta$", xy=(β + 0.01, 0.5), fontsize=14)
-ax.annotate(r"$\alpha$", xy=(α + 0.01, 0.5), fontsize=14)
+ax.annotate(r"$B$", xy=(B + 0.01, 0.5), fontsize=14)
+ax.annotate(r"$A$", xy=(A + 0.01, 0.5), fontsize=14)
 
-plt.vlines(β, 0, β * wf.L0, linestyle="--")
-plt.vlines(α, 0, (1 - α) * wf.L1, linestyle="--")
+plt.vlines(B, 0, B * wf.L0, linestyle="--")
+plt.vlines(A, 0, (1 - A) * wf.L1, linestyle="--")
 
 ax.set(xlim=(0, 1), ylim=(0, 0.5 * max(wf.L0, wf.L1)), ylabel="成本",
        xlabel=r"$\pi$", title="值函数")
@@ -551,13 +570,13 @@ plt.show()
 
 上图描绘了价值函数对决策者贝叶斯后验概率的关系。
 
-图中还显示了概率 $\alpha$ 和 $\beta$。
+图中还显示了临界概率 $A$ 和 $B$。
 
 贝叶斯决策规则是：
 
-- 当 $\pi \geq \alpha$ 时接受 $H_0$
-- 当 $\pi \leq \beta$ 时接受 $H_1$
-- 当 $\beta \leq \pi \leq \alpha$ 时延迟决定并抽取另一个 $z$
+- 当 $\pi \geq A$ 时接受 $H_0$
+- 当 $\pi \leq B$ 时接受 $H_1$
+- 当 $B \leq \pi \leq A$ 时延迟决定并抽取另一个 $z$
 
 在这种情况下，我们可以计算两个"客观"损失函数，分别基于确知自然选择了 $f_{0}$ 或 $f_{1}$ 的条件。
 
@@ -565,24 +584,23 @@ plt.show()
 
    $$
    V^{0}\left(\pi\right)=\begin{cases}
-   0 & \text{if }\alpha\leq\pi,\\
-   c+EV^{0}\left(\pi^{\prime}\right) & \text{if }\beta\leq\pi<\alpha,\\
-   \bar L_{1} & \text{if }\pi<\beta.
+   0 & \text{if} A \leq\pi,\\
+   c+EV^{0}\left(\pi^{\prime}\right) & \text{if }B\leq\pi< A,\\
+   \bar L_{1} & \text{if }\pi<B.
    \end{cases}
    $$
 
-1. 在 $f_{1}$ 下，
+1. 在 $f_{1}$ 下
 
    $$
    V^{1}\left(\pi\right)=\begin{cases}
-   \bar L_{0} & \text{if }\alpha\leq\pi,\\
-   c+EV^{1}\left(\pi^{\prime}\right) & \text{if }\beta\leq\pi<\alpha,\\
-   0 & \text{if }\pi<\beta.
+   \bar L_{0} & \text{if }A \leq\pi,\\
+   c+EV^{1}\left(\pi^{\prime}\right) & \text{if }B \leq\pi<A,\\
+   0 & \text{if }\pi< B.
    \end{cases}
    $$
 
 其中
-
 $\pi^{\prime}=\frac{\pi f_{0}\left(z^{\prime}\right)}{\pi f_{0}\left(z^{\prime}\right)+\left(1-\pi\right)f_{1}\left(z^{\prime}\right)}$。
 
 给定先验概率 $\pi_{0}$，贝叶斯方法的期望损失为
@@ -599,21 +617,21 @@ def V_q(wf, flag):
     V = np.zeros(wf.π_grid_size)
     if flag == 0:
         z_arr = wf.z0
-        V[wf.π_grid < β] = wf.L1
+        V[wf.π_grid < B] = wf.L1
     else:
         z_arr = wf.z1
-        V[wf.π_grid >= α] = wf.L0
+        V[wf.π_grid >= A] = wf.L0
 
     V_old = np.empty_like(V)
 
     while True:
         V_old[:] = V[:]
-        V[(β <= wf.π_grid) & (wf.π_grid < α)] = 0
+        V[(B <= wf.π_grid) & (wf.π_grid < A)] = 0
 
         for i in prange(len(wf.π_grid)):
             π = wf.π_grid[i]
 
-            if π >= α or π < β:
+            if π >= A or π < B:
                 continue
 
             for j in prange(len(z_arr)):
@@ -634,12 +652,12 @@ V1 = V_q(wf, 1)
 
 plt.plot(wf.π_grid, V0, label='$V^0$')
 plt.plot(wf.π_grid, V1, label='$V^1$')
-plt.vlines(β, 0, wf.L0, linestyle='--')
-plt.text(β+0.01, wf.L0/2, 'β')
-plt.vlines(α, 0, wf.L0, linestyle='--')
-plt.text(α+0.01, wf.L0/2, 'α')
+plt.vlines(B, 0, wf.L0, linestyle='--')
+plt.text(B+0.01, wf.L0/2, 'B')
+plt.vlines(A, 0, wf.L0, linestyle='--')
+plt.text(A+0.01, wf.L0/2, 'A')
 plt.xlabel(r'$\pi$')
-plt.title('目标值函数 $V(\pi)$')
+plt.title(r'目标值函数 $V(\pi)$')
 plt.legend()
 plt.show()
 ```
@@ -651,7 +669,7 @@ $\pi^{*}=\Pr\left\{ \text{自然选择 }f_{0}\right\}$，我们就可以
 然后我们可以确定一个初始贝叶斯先验概率 $\pi_{0}^{*}$，使其
 最小化这个期望损失的客观概念。
 
-下面的图9展示了四种情况，分别对应
+下面的图展示了四种情况，分别对应
 $\pi^{*}=0.25,0.3,0.5,0.7$。
 
 我们观察到在每种情况下 $\pi_{0}^{*}$ 都等于 $\pi^{*}$。
@@ -682,7 +700,7 @@ for i, π_star in enumerate(π_star_arr):
     axs[row_i, col_i].hlines(V_baye_bar, 0, 1, linestyle='--')
     axs[row_i, col_i].vlines(π_optimal, V_baye_bar, V_baye.max(), linestyle='--')
     axs[row_i, col_i].text(π_optimal+0.05, (V_baye_bar + V_baye.max()) / 2,
-                        '${\pi_0^*}=$'+f'{π_optimal:0.2f}')
+                        r'${\pi_0^*}=$'+f'{π_optimal:0.2f}')
     axs[row_i, col_i].set_xlabel(r'$\pi$')
     axs[row_i, col_i].set_ylabel(r'$\overline{V}_{baye}(\pi)$')
     axs[row_i, col_i].set_title(r'$\pi^*=$' + f'{π_star}')
@@ -718,7 +736,7 @@ axs[1].plot([π_star_arr.min(), π_star_arr.max()],
             [π_star_arr.min(), π_star_arr.max()],
             c='k', linestyle='--', label='45 degree line')
 axs[1].set_xlabel(r'$\pi^*$')
-axs[1].set_title('optimal prior given $\pi^*$')
+axs[1].set_title(r'给定$\pi^*$的最优先验')
 axs[1].legend()
 
 plt.show()
@@ -726,7 +744,7 @@ plt.show()
 
 ## 海军上尉的直觉是否正确？
 
-现在我们比较频率主义和贝叶斯决策规则所得到的平均（即频率主义）损失。
+现在我们比较通过频率派Neyman-Pearson规则和贝叶斯决策规则得到的平均损失。
 
 让我们先从比较$\pi^{*}=0.5$时的平均损失函数开始。
 
@@ -739,7 +757,7 @@ plt.show()
 V_fre_arr, PFA_arr, PD_arr = compute_V_fre(L0_arr, L1_arr, π_star, wf)
 
 # 贝叶斯派
-V_baye = π_star * V0 + π_star * V1
+V_baye = π_star * V0 + (1 - π_star) * V1
 V_baye_bar = V_baye.min()
 ```
 
@@ -752,7 +770,7 @@ plt.legend()
 plt.show()
 ```
 
-显然，在任何样本量 $t$ 下，频率派决策规则都无法获得比贝叶斯规则更低的损失函数。
+显然，在任何样本量 $t$ 下，Neyman-Pearson决策规则都无法获得比贝叶斯规则更低的损失函数。
 
 此外，下图表明贝叶斯决策规则在所有 $\pi^{*}$ 值上平均表现都更好。
 
@@ -783,7 +801,7 @@ plt.show()
 π_star = 0.5
 ```
 
-回顾当$\pi^*=0.5$时，频率派决策规则会**事先**设定一个样本量`t_optimal`。
+回顾当$\pi^*=0.5$时，频率派Neyman-Pearson决策规则会**事先**设定一个样本量`t_optimal`。
 
 对于我们的参数设置，我们可以计算它的值：
 
@@ -809,7 +827,7 @@ t_idx = t_optimal - 1
 
 ```{code-cell} ipython3
 @jit(parallel=True)
-def check_results(L_arr, α, β, flag, π0):
+def check_results(L_arr, A, B, flag, π0):
 
     N, T = L_arr.shape
 
@@ -820,17 +838,17 @@ def check_results(L_arr, α, β, flag, π0):
 
     for i in prange(N):
         for t in range(T):
-            if (π_arr[i, t] < β) or (π_arr[i, t] > α):
+            if (π_arr[i, t] < B) or (π_arr[i, t] > A):
                 time_arr[i] = t + 1
-                correctness[i] = (flag == 0 and π_arr[i, t] > α) or (flag == 1 and π_arr[i, t] < β)
+                correctness[i] = (flag == 0 and π_arr[i, t] > A) or (flag == 1 and π_arr[i, t] < B)
                 break
 
     return time_arr, correctness
 ```
 
 ```{code-cell} ipython3
-time_arr0, correctness0 = check_results(L0_arr, α, β, 0, π_star)
-time_arr1, correctness1 = check_results(L1_arr, α, β, 1, π_star)
+time_arr0, correctness0 = check_results(L0_arr, A, B, 0, π_star)
+time_arr1, correctness1 = check_results(L1_arr, A, B, 1, π_star)
 
 # 无条件分布
 time_arr_u = np.concatenate((time_arr0, time_arr1))
@@ -854,11 +872,11 @@ plt.title('时间的条件频率分布')
 plt.show()
 ```
 
-稍后我们将弄清这些分布最终如何影响两种决策规则下的客观期望值。
+稍后我们将弄清这些分布最终如何影响Neyman-Pearson和贝叶斯决策规则下的客观期望值。
 
 首先，让我们看看贝叶斯信念随时间的模拟。
 
-利用本讲{doc}`似然比过程 <likelihood_ratio_process>`中描述的从$L_{t}$到$\pi_{t}$的一一映射（给定$\pi_0$），我们可以轻松计算任意时间$t$的更新信念。
+利用本讲{doc}`似然比过程 <likelihood_ratio_process>`中描述的从$L_{t}$到$\pi_{t}$的一一映射（给定$\pi_0$），我们可以计算任意时间$t$的更新信念。
 
 ```{code-cell} ipython3
 π0_arr = π_star * L0_arr / (π_star * L0_arr + 1 - π_star)
@@ -871,14 +889,14 @@ fig, axs = plt.subplots(1, 2, figsize=(14, 4))
 axs[0].plot(np.arange(1, π0_arr.shape[1]+1), np.mean(π0_arr, 0), label='f0生成')
 axs[0].plot(np.arange(1, π1_arr.shape[1]+1), 1 - np.mean(π1_arr, 0), label='f1生成')
 axs[0].set_xlabel('t')
-axs[0].set_ylabel('$E(\pi_t)$ 或 ($1 - E(\pi_t)$)')
+axs[0].set_ylabel(r'$E(\pi_t)$ 或 ($1 - E(\pi_t)$)')
 axs[0].set_title('抽取t个观测值后信念的期望')
 axs[0].legend()
 
 axs[1].plot(np.arange(1, π0_arr.shape[1]+1), np.var(π0_arr, 0), label='f0生成')
 axs[1].plot(np.arange(1, π1_arr.shape[1]+1), np.var(π1_arr, 0), label='f1生成')
 axs[1].set_xlabel('t')
-axs[1].set_ylabel('var($\pi_t$)')
+axs[1].set_ylabel(r'var($\pi_t$)')
 axs[1].set_title('抽取t个观测值后信念的方差')
 axs[1].legend()
 
@@ -913,14 +931,14 @@ plt.show()
 
 ## 做出正确决策的概率
 
-现在我们使用模拟来计算贝叶斯和频率主义决策规则做出正确决定的样本比例。
+现在我们使用模拟来计算贝叶斯和频率派Neyman-Pearson决策规则做出正确决定的样本比例。
 
-对于频率主义规则，在$f_{1}$下做出正确决定的概率是我们之前定义的给定$t$时的最优检测概率，同样地，在$f_{0}$下它等于1减去最优虚警概率。
+对于频率派Neyman-Pearson规则，在$f_{1}$下做出正确决定的概率是我们之前定义的给定$t$时的最优检测概率，同样地，它等于1减去$f_{0}$下的最优虚警概率。
 
-下面我们绘制频率主义规则的这两个概率，以及贝叶斯规则在$t$之前做出决定*且*决定正确的条件概率。
+下面我们绘制频率派规则的这两个概率，以及贝叶斯规则在$t$之前做出决定*且*决定正确的条件概率。
 
 ```{code-cell} ipython3
-# 频率主义最优样本量下的最优虚警概率和检测概率
+# 频率派最优样本量下的最优虚警概率和检测概率
 V, PFA, PD = V_fre_t(t_optimal, L0_arr, L1_arr, π_star, wf)
 ```
 
@@ -963,19 +981,19 @@ plt.title('t时刻前做出正确决策的无条件概率')
 plt.show()
 ```
 
-## 在频率学家的 $t$ 处的似然比分布
+## Neyman-Pearson的$t$处的似然比分布
 
 接下来我们使用模拟来构建在 $t$ 次抽样后的似然比分布。
 
-作为有用的参考点，我们还展示了对应于贝叶斯截断值 $\alpha$ 和 $\beta$ 的似然比。
+作为有用的参考点，我们还展示了对应于贝叶斯截断值 $A$ 和 $B$ 的似然比。
 
 为了更清晰地展示分布，我们报告似然比的对数值。
 
 下面的图表报告了两个分布，一个是在 $f_0$ 生成数据的条件下的分布，另一个是在 $f_1$ 生成数据的条件下的分布。
 
 ```{code-cell} ipython3
-Lα = (1 - π_star) *  α / (π_star - π_star * α)
-Lβ = (1 - π_star) *  β / (π_star - π_star * β)
+LA = (1 - π_star) *  A / (π_star - π_star * A)
+LB = (1 - π_star) *  B / (π_star - π_star * B)
 ```
 
 ```{code-cell} ipython3
@@ -985,8 +1003,8 @@ bin_range = np.linspace(np.log(L_min), np.log(L_max), 50)
 n0 = plt.hist(np.log(L0_arr[:, t_idx]), bins=bin_range, alpha=0.4, label='f0生成')[0]
 n1 = plt.hist(np.log(L1_arr[:, t_idx]), bins=bin_range, alpha=0.4, label='f1生成')[0]
 
-plt.vlines(np.log(Lβ), 0, max(n0.max(), n1.max()), linestyle='--', color='r', label='log($L_β$)')
-plt.vlines(np.log(Lα), 0, max(n0.max(), n1.max()), linestyle='--', color='b', label='log($L_α$)')
+plt.vlines(np.log(LB), 0, max(n0.max(), n1.max()), linestyle='--', color='r', label='log($L_B$)')
+plt.vlines(np.log(LA), 0, max(n0.max(), n1.max()), linestyle='--', color='b', label='log($L_A$)')
 plt.legend()
 
 plt.xlabel('log(L)')
@@ -1001,8 +1019,8 @@ plt.show()
 ```{code-cell} ipython3
 plt.hist(np.log(np.concatenate([L0_arr[:, t_idx], L1_arr[:, t_idx]])),
         bins=50, alpha=0.4, label='log(L)的无条件分布')
-plt.vlines(np.log(Lβ), 0, max(n0.max(), n1.max()), linestyle='--', color='r', label='log($L_β$)')
-plt.vlines(np.log(Lα), 0, max(n0.max(), n1.max()), linestyle='--', color='b', label='log($L_α$)')
+plt.vlines(np.log(LB), 0, max(n0.max(), n1.max()), linestyle='--', color='r', label='log($L_B$)')
+plt.vlines(np.log(LA), 0, max(n0.max(), n1.max()), linestyle='--', color='b', label='log($L_A$)')
 plt.legend()
 
 plt.xlabel('log(L)')
@@ -1011,4 +1029,3 @@ plt.title('频率论者t时刻的对数似然比的无条件分布')
 
 plt.show()
 ```
-

--- a/lectures/navy_captain.md
+++ b/lectures/navy_captain.md
@@ -383,7 +383,7 @@ def compute_V_fre(L0_arr, L1_arr, π_star, wf):
 V_fre_arr, PFA_arr, PD_arr = compute_V_fre(L0_arr, L1_arr, π_star, wf)
 
 plt.plot(range(T), V_fre_arr, label=r'$\min_{d} \overline{V}_{fre}(t,d)$')
-plt.xlabel('t')
+plt.xlabel('时间t')
 plt.title(r'$\pi^*=0.5$')
 plt.legend()
 plt.show()
@@ -924,7 +924,7 @@ plt.legend()
 
 plt.xlabel('t')
 plt.ylabel('n')
-plt.title('Unconditional distribution of times')
+plt.title('目标值函数 $V(\pi)$')
 
 plt.show()
 ```


### PR DESCRIPTION
## Forward Resync: navy_captain.md

**Source**: [QuantEcon/lecture-python.myst](https://github.com/QuantEcon/lecture-python.myst) — [lectures/navy_captain.md](https://github.com/QuantEcon/lecture-python.myst/blob/main/lectures/navy_captain.md)
**Source commit**: [`36bc72e`](https://github.com/QuantEcon/lecture-python.myst/commit/36bc72ea8fe852f84c63534cd0530c549c43c5cc)
This PR resyncs the translation to match the current source document.

**Reason**: The Chinese translation has substantial content divergences from the source: missing lecture references (e.g. 'A Bayesian Formulation of Friedman and Wald's Problem' link dropped in multiple places), garbled/incomplete sentences (e.g. the setup section's bullet list is cut off and merged incorrectly), renamed symbols A/B changed to α/β with altered explanatory text (mentioning 'Milton Friedman and Allen Wallis' which isn't in source), incorrect V_baye formula using π_star*V1 instead of (1-π_star)*V1, some print statements replacing markdown text, and mismatched code cell counts/labels (e.g. 'ipython3' vs 'python3' - stylistic, but content like missing bullet points describing frequentist decision rule cutoffs is missing). These are substantive content changes, not just stylistic differences.

### Changes

Whole-file resync applied. The entire document was resynced in a single pass.

---
*Created by [action-translation](https://github.com/QuantEcon/action-translation) forward resync*

<!-- translation-sync-metadata
{
  "sourceRepo": "QuantEcon/lecture-python.myst",
  "sourcePR": 0,
  "mode": "resync",
  "sourceCommitSha": "36bc72ea8fe852f84c63534cd0530c549c43c5cc",
  "targetBaseSha": "753de32c72c8790bb707e1fe24e28ff3c24126ee",
  "sourceLanguage": "en",
  "targetLanguage": "zh-cn",
  "claudeModel": "claude-sonnet-5",
  "files": [
    {
      "path": "lectures/navy_captain.md",
      "type": "markdown"
    },
    {
      "path": ".translate/state/navy_captain.md.yml"
    }
  ]
}
-->