### PR TITLE
Align build environment with the English source (supersedes the env half of #97)

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -3,15 +3,17 @@ channels:
   - default
 dependencies:
   - python=3.13
-  - anaconda=2025.06
+  - anaconda=2026.06
   - pip
   - pip:
-    - jupyter-book==1.0.4post1
-    - quantecon-book-theme==0.10.1
-    - sphinx-tojupyter==0.3.1
-    - sphinxext-rediraffe==0.2.7
-    - sphinx-exercise==1.2.0
-    - sphinx-proof==0.3.0
-    - sphinxcontrib-youtube==1.4.1
-    - sphinx-togglebutton==0.3.2
-    - sphinx-reredirects==0.1.4
+    - jupyter-book>=1.0.4post1,<2.0
+    - quantecon-book-theme==0.21.0
+    - sphinx-tojupyter==0.6.0
+    - sphinxext-rediraffe==0.3.0
+    - sphinx-exercise==1.2.1
+    - sphinx-proof==0.4.0
+    - sphinxcontrib-youtube==1.5.0
+    - sphinx-togglebutton==0.4.5
+    - sphinx-reredirects==1.1.0
+
+

--- a/lectures/_config.yml
+++ b/lectures/_config.yml
@@ -38,6 +38,7 @@ sphinx:
     # false-positive links
     linkcheck_ignore: ['https://online.stat.psu.edu/stat415/book/export/html/834']
     bibtex_reference_style: author_year
+    nb_merge_streams: true
     nb_mime_priority_overrides: [
        # HTML
        ['html', 'application/vnd.jupyter.widget-view+json', 10],


### PR DESCRIPTION
Copies lecture-python.myst's current `environment.yml` (anaconda **2026.06**, jupyter-book `>=1.0.4post1,<2.0`, quantecon-book-theme **0.21.0**, sphinx-tojupyter **0.6.0**, current sphinx-* pins) and adds the source's `nb_merge_streams: true` to `_config.yml`. The Track B resync wave (#101–#164) brings lecture code to the source's 2026-era state — it should build against the same stack the source executes under, not the 2025.06 pins on main.

**Relationship to #97**: that PR was current when opened in December (anaconda 2025.12 / theme 0.15.1) but is now seven months behind the source. This PR supersedes its environment/config changes; #97's remaining pieces (dependabot config, workflow action-version bumps) are untouched here and can still be merged or cherry-picked — Matt's call whether to rebase #97 down to those or close it.

**Not touched**: `environment-cn.yml` — no workflow references it (all three use `environment.yml`); consider deleting it separately as dead config.

**After merging**: dispatch the cache workflow so the execution cache rebuilds under the new environment, then re-run wave-PR checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)