### PR TITLE
Add translated _admonition/gpu.md (referenced but missing)

### DIFF
--- a/lectures/_admonition/gpu.md
+++ b/lectures/_admonition/gpu.md
@@ -1,0 +1,11 @@
+```{admonition} GPU
+:class: warning
+
+本讲座是在配有GPU的机器上构建的——不过没有GPU也可以运行。
+
+[Google Colab](https://colab.research.google.com/) 提供带GPU的免费套餐，使用方法如下：
+
+1. 点击右上角的"播放"图标
+2. 选择 Colab
+3. 将运行时环境设置为包含GPU
+```


### PR DESCRIPTION
mix_model.md on main and several resync-wave files include `_admonition/gpu.md`, but the directory never existed in this repo. Adds the Chinese translation of the source's 12-line admonition. Found during the 7-PR merge review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)