### PR TITLE
Restore missing 'import matplotlib as mpl' in mix_model font block

### DIFF
--- a/lectures/mix_model.md
+++ b/lectures/mix_model.md
@@ -116,6 +116,7 @@ $$
 :hide-output: false
 
 import matplotlib.pyplot as plt
+import matplotlib as mpl
 FONTPATH = "fonts/SourceHanSerifSC-SemiBold.otf"
 mpl.font_manager.fontManager.addfont(FONTPATH)
 plt.rcParams['font.family'] = ['Source Han Serif SC']


### PR DESCRIPTION
The CJK font-configuration block in `lectures/mix_model.md` calls `mpl.font_manager.fontManager.addfont(...)` but the `import matplotlib as mpl` line is missing, so the lecture fails execution with `NameError: name 'mpl' is not defined` whenever it is re-executed (confirmed in the 2026-07-18 cache-rebuild execution reports).

This is the same residual class field-validated in QuantEcon/action-translation#107 (partial font-block drops). mix_model was triaged I18N_ONLY in the resync wave — content-equivalent to source, so no wave PR covers it — which is how a broken font block slipped past: triage checks content equivalence, not executability.

One line restores the import, matching the canonical font block used across the repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
