### PR TITLE
FIX: execution and doc failures from the Anaconda 2026.07 cache build (closes #182)

### DIFF
--- a/lectures/ak_aiyagari.md
+++ b/lectures/ak_aiyagari.md
@@ -10,7 +10,7 @@ kernelspec:
   language: python
   name: python3
 translation:
-  title: V, σ, μ
+  title: 长寿、异质性个体、世代交叠模型
   headings:
     Overview: 概述
     Environment: 经济环境
@@ -34,21 +34,6 @@ translation:
     'Experiment 1: Immediate tax cut': 实验1：即时减税
     'Experiment 2: Preannounced tax cut': 实验2：预先宣布的减税
 ---
-
-```
----
-jupytext:
-  text_representation:
-    extension: .md
-    format_name: myst
-    format_version: 0.13
-    jupytext_version: 1.17.3
-kernelspec:
-  display_name: Python 3 (ipykernel)
-  language: python
-  name: python3
----
-
 
 # 长寿、异质性个体、世代交叠模型
 
@@ -1476,5 +1461,4 @@ ax2.set_xlabel(r"t")
 ax2.set_ylabel(r"j")
 
 plt.show()
-```
 ```

--- a/lectures/kalman_2.md
+++ b/lectures/kalman_2.md
@@ -352,8 +352,8 @@ for i, t in enumerate(np.linspace(0, T-1, 3, dtype=int)):
     axs[i].set_ylabel(r'$u_{{{}}}$'.format(str(t)))
     
     cov_latex = (
-        r'$\Sigma_{{{}}}= \begin{{bmatrix}} {:.2f} & {:.2f} \\ '
-        r'{:.2f} & {:.2f} \end{{bmatrix}}$'
+        r'$\Sigma_{{{}}}= \left[ \substack{{{:.2f} \; {:.2f} \\ '
+        r'{:.2f} \; {:.2f}}} \right]$'
     ).format(t, cov[0, 0], cov[0, 1], cov[1, 0], cov[1, 1])
     axs[i].text(0.33, -0.15, cov_latex, transform=axs[i].transAxes)
 

--- a/lectures/likelihood_bayes.md
+++ b/lectures/likelihood_bayes.md
@@ -62,10 +62,10 @@ translation:
 
 FONTPATH = "fonts/SourceHanSerifSC-SemiBold.otf"
 import matplotlib as mpl
+import matplotlib.pyplot as plt
 mpl.font_manager.fontManager.addfont(FONTPATH)
 plt.rcParams['font.family'] = ['Source Han Serif SC']
 
-import matplotlib.pyplot as plt
 import numpy as np
 from numba import vectorize, jit, prange
 from math import gamma

--- a/lectures/sir_model.md
+++ b/lectures/sir_model.md
@@ -21,7 +21,7 @@ translation:
     Ending Lockdown: 解除封锁
 ---
 
-```{raw}
+```{raw} jupyter
 <div id="qe-notebook-header" align="right" style="text-align:right;">
         <a href="https://quantecon.org/" title="quantecon.org">
                 <img style="width:250px;display:inline;" width="250px" src="https://assets.quantecon.org/img/qe-menubar-logo.svg" alt="QuantEcon">


### PR DESCRIPTION
Resolves the four failures reported in #182. All four are target-side defects — the English source is healthy in every case, so none of these is an upstream backport.

## The four fixes

**`likelihood_bayes` — execution break.** The font block called `mpl.font_manager.fontManager` and `plt.rcParams` before `import matplotlib.pyplot as plt`. Newer matplotlib no longer imports `font_manager` as a side effect of `import matplotlib`, so this raised `AttributeError` — and would have raised `NameError` on `plt` regardless. Moved the pyplot import above both uses. I audited the font block across all 69 lectures: this is the only file with either ordering hazard.

**`kalman_2` — execution break.** A `.text()` annotation drew the covariance matrix with `\begin{bmatrix}`, which matplotlib mathtext cannot render — mathtext supports no LaTeX environments at all. Rewritten as `\left[ \substack{...} \right]` with `\;` as the column separator instead of `&`, which renders an equivalent bracketed 2×2 matrix and was verified by rendering it with real formatted values. This keeps the drop-usetex standard from #22 intact with no loss of information, so no exception to that standard is needed. The lecture's other `\begin{bmatrix}` uses are inside `{math}` blocks, rendered by MathJax in the browser, and were never at risk.

Worth noting for future sweeps: this site is invisible to a naive grep, because the braces are `.format()`-escaped as `\begin{{bmatrix}}`.

**`sir_model` — doc error.** The header directive had lost its argument: ```` ```{raw} ```` instead of ```` ```{raw} jupyter ````. The other 50 lectures carrying this directive kept theirs.

**`ak_aiyagari` — doc error, with a larger cause than #182 diagnosed.** The issue recommended restoring a single H1. That would have papered over the actual bug. The file carried a stray fence immediately after the frontmatter, followed by a duplicated copy of the original frontmatter, plus a doubled closing fence at EOF. The stray opener ran to line 56, swallowing both the H1 title **and** the `_admonition/gpu.md` include — which is what produced the 13 "headings start at H2" warnings. Restoring an H1 alone would have left the include broken.

Removed both strays. The file's fence structure now matches the English source exactly (122 fences, balanced). The `translation.title` field was also corrupt — it read `V, σ, μ`, which is a Python tuple-unpacking line from deep inside a code cell in the source — and has been set to the lecture title.

## Provenance

`ak_aiyagari`'s corruption was introduced by the resync in #103. Before it (`a664481`) the file had 120 fences and was balanced; after (`17b5b98`) it had 124 with both strays present. The engine emitted its new `translation:` frontmatter, then an opening fence, then the entire original document verbatim, then a closing fence at EOF — it wrapped the document body in a code block. The corrupt `translation.title` points at the same root cause: the engine failed to parse this file's structure and fell back to a degraded path that mis-derived the title too.

This warrants an engine issue against `action-translation`; it is not covered by the existing #107/#115/#116/#117 set. Same for the `{raw}` argument stripping.

## Verification

- Fence balance now matches the English source exactly; an edition-wide sweep found no other unbalanced file, and a fleet sweep across all edition clones found none either.
- `code-cell` counts match the English source for all four files.
- The `kalman_2` replacement was rendered with real formatted values to confirm it produces a correct bracketed matrix, rather than only checking that it parses (`\substack` with `&` parses but renders the ampersand literally — that trap is why).
- Trailing newlines present on all four files.

**What is not verified:** none of this has been cold-executed. Per QuantEcon/meta#340 this repo's `ci.yml` sphinx-tojupyter step lacks `-n -W`, so a green build here is weak evidence for the two execution fixes. See the note below.

## On build parity — deliberately not in this PR

Comparing `ci.yml` against the source repo `lecture-python.myst` confirms meta#340 and widens it. The source's sphinx-tojupyter step runs `-n -W --keep-going`; this repo's runs with no flags. The source also has a "Clear stale Sphinx environment" step and execution-report artifact uploads for the notebook and LaTeX builds that this repo lacks, so when that step does fail here there is no traceback artifact to read.

I have kept that out of this PR on purpose. Turning on `-n -W` will surface every remaining latent failure in the edition at once — and there almost certainly are some, since the cache build that produced #182 reused old-environment cache for roughly 15 unchanged lectures that were never re-tested. Folding it in here would likely turn this PR red for reasons unrelated to its own fixes. Content first, then the safety flag as its own PR that is *expected* to surface more.

Closes #182

🤖 Generated with [Claude Code](https://claude.com/claude-code)