### PR TITLE
CI: align build safety with the English source repo (closes #184)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,12 @@ jobs:
       - name: Build Download Notebooks (sphinx-tojupyter)
         shell: bash -l {0}
         run: |
+          # `shell: bash -l {0}` is a custom shell spec, so GitHub does not inject
+          # `-eo pipefail` (it only does that for the bare `shell: bash` shorthand).
+          # Without this, a failing `jb build` would be masked by the trailing
+          # mkdir/cp, whose exit code becomes the step's — and `--keep-going`
+          # guarantees the .ipynb files exist for `cp` to succeed on.
+          set -eo pipefail
           jb build lectures -n -W --keep-going --path-output ./ --builder=custom --custom-builder=jupyter
           mkdir -p _build/html/_notebooks
           cp -u _build/jupyter/*.ipynb _build/html/_notebooks

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,9 @@ jobs:
           branch: main
           name: build-cache
           path: _build
+      - name: Clear stale Sphinx environment
+        shell: bash -l {0}
+        run: rm -rf _build/.doctrees
       # # Build Assets (Download Notebooks and PDF via LaTeX)
       # - name: Build PDF from LaTeX
       #   shell: bash -l {0}
@@ -63,13 +66,16 @@ jobs:
       - name: Build Download Notebooks (sphinx-tojupyter)
         shell: bash -l {0}
         run: |
-          jb build lectures --path-output ./ --builder=custom --custom-builder=jupyter
+          jb build lectures -n -W --keep-going --path-output ./ --builder=custom --custom-builder=jupyter
           mkdir -p _build/html/_notebooks
           cp -u _build/jupyter/*.ipynb _build/html/_notebooks
+      - name: Upload Execution Reports (Download Notebooks)
+        uses: actions/upload-artifact@v7
+        if: failure()
+        with:
+          name: execution-reports-notebooks
+          path: _build/jupyter/reports
       # Build HTML (Website)
-      # BUG: rm .doctress to remove `sphinx` rendering issues for ipywidget mimetypes
-      # and clear the sphinx cache for building final HTML documents.
-      #    rm -r _build/.doctrees
       - name: Build HTML
         shell: bash -l {0}
         run: |
@@ -78,7 +84,7 @@ jobs:
         uses: actions/upload-artifact@v7
         if: failure()
         with:
-          name: execution-reports
+          name: execution-reports-html
           path: _build/html/reports
       - name: Preview Deploy to Netlify
         uses: nwtgck/actions-netlify@v4.0

--- a/lectures/ak_aiyagari.md
+++ b/lectures/ak_aiyagari.md
@@ -10,7 +10,7 @@ kernelspec:
   language: python
   name: python3
 translation:
-  title: V, σ, μ
+  title: 长寿、异质性个体、世代交叠模型
   headings:
     Overview: 概述
     Environment: 经济环境
@@ -34,21 +34,6 @@ translation:
     'Experiment 1: Immediate tax cut': 实验1：即时减税
     'Experiment 2: Preannounced tax cut': 实验2：预先宣布的减税
 ---
-
-```
----
-jupytext:
-  text_representation:
-    extension: .md
-    format_name: myst
-    format_version: 0.13
-    jupytext_version: 1.17.3
-kernelspec:
-  display_name: Python 3 (ipykernel)
-  language: python
-  name: python3
----
-
 
 # 长寿、异质性个体、世代交叠模型
 
@@ -1476,5 +1461,4 @@ ax2.set_xlabel(r"t")
 ax2.set_ylabel(r"j")
 
 plt.show()
-```
 ```

--- a/lectures/kalman_2.md
+++ b/lectures/kalman_2.md
@@ -352,8 +352,8 @@ for i, t in enumerate(np.linspace(0, T-1, 3, dtype=int)):
     axs[i].set_ylabel(r'$u_{{{}}}$'.format(str(t)))
     
     cov_latex = (
-        r'$\Sigma_{{{}}}= \begin{{bmatrix}} {:.2f} & {:.2f} \\ '
-        r'{:.2f} & {:.2f} \end{{bmatrix}}$'
+        r'$\Sigma_{{{}}}= \left[ \substack{{{:.2f} \; {:.2f} \\ '
+        r'{:.2f} \; {:.2f}}} \right]$'
     ).format(t, cov[0, 0], cov[0, 1], cov[1, 0], cov[1, 1])
     axs[i].text(0.33, -0.15, cov_latex, transform=axs[i].transAxes)
 

--- a/lectures/likelihood_bayes.md
+++ b/lectures/likelihood_bayes.md
@@ -62,10 +62,10 @@ translation:
 
 FONTPATH = "fonts/SourceHanSerifSC-SemiBold.otf"
 import matplotlib as mpl
+import matplotlib.pyplot as plt
 mpl.font_manager.fontManager.addfont(FONTPATH)
 plt.rcParams['font.family'] = ['Source Han Serif SC']
 
-import matplotlib.pyplot as plt
 import numpy as np
 from numba import vectorize, jit, prange
 from math import gamma

--- a/lectures/sir_model.md
+++ b/lectures/sir_model.md
@@ -21,7 +21,7 @@ translation:
     Ending Lockdown: 解除封锁
 ---
 
-```{raw}
+```{raw} jupyter
 <div id="qe-notebook-header" align="right" style="text-align:right;">
         <a href="https://quantecon.org/" title="quantecon.org">
                 <img style="width:250px;display:inline;" width="250px" src="https://assets.quantecon.org/img/qe-menubar-logo.svg" alt="QuantEcon">


### PR DESCRIPTION
Resolves #184. Split out of #183 so that PR stayed scoped to content fixes.

**Stacked on #183.** The base is `fix/182-execution-and-doc-failures`, not `main`, so the diff here is just `ci.yml` and the CI run reflects reality — turning on `-n -W` against a main that still contains the four #182 defects would only re-report bugs #183 already fixes. GitHub will retarget this to `main` automatically when #183 merges.

## What changes

| Step | Before | After |
|---|---|---|
| Clear stale Sphinx environment | absent (commented note only) | added, matching source |
| Build Download Notebooks (sphinx-tojupyter) | **no flags** | `-n -W --keep-going` |
| Upload Execution Reports (Download Notebooks) | absent | added, `if: failure()` |
| Build HTML | `-n -W --keep-going` | unchanged |
| Build PDF from LaTeX | commented out | **left alone** — see below |

The sphinx-tojupyter step is the substantive fix. It ran with no flags, so a notebook whose cells raised still exited zero and the job went green — that is how the two execution breaks in #182 (`likelihood_bayes`, `kalman_2`) reached main with passing CI.

The missing artifact upload compounded it: when that step did fail there was no traceback to read, which is why #182 had to be diagnosed from the weekly Build Cache workflow's artifact instead of from CI.

## One non-obvious change

The HTML artifact is renamed `execution-reports` → `execution-reports-html`. This is **required, not cosmetic**. `upload-artifact@v7` runs with `overwrite: false`, so adding a second upload under the existing `execution-reports` name would collide whenever both steps fail in the same run. The new names follow the source repo's convention (`-notebooks` / `-latex` / `-html`).

## Expect this to go red, and that is the point

Turning on `-n -W` surfaces every remaining latent failure at once, and there are very likely more than the four in #182. The Build Cache run that produced #182 is content-addressed: it re-executed only the lectures the resync wave changed, and **reused old-environment cache for roughly 15 unchanged lectures** that have never executed under anaconda 2026.07. Whatever this run reports is the real backlog.

The useful reading: a red run here is new information, not a regression. Work the list, then merge.

## Verification

- YAML parses; 13 steps.
- Step-for-step parity against `lecture-python.myst` confirmed from `Download "build" folder (cache)` through `Upload Execution Reports (Download Notebooks)`. Remaining divergence is the PDF/LaTeX pair and the source repo's GPU/JAX setup steps, neither of which applies here.
- Both `jb build` invocations now carry `-n -W --keep-going`.

## Left deliberately undone

The PDF/LaTeX build stays commented out. CJK under LaTeX is hard, and more so since #22 dropped `text.usetex`, so this looks like a considered choice rather than an oversight. It needs a human decision, not mechanical alignment — flagged in #184.

Related: QuantEcon/meta#340 tracks the same gap across the fleet (`lecture-intro.zh-cn` and the `lecture-python-intro` source repo have it too; `lecture-python-programming` is already aligned).

Closes #184

🤖 Generated with [Claude Code](https://claude.com/claude-code)