### PR TITLE
Rebase: also match resync/* branches (action-translation v0.18.1)

### DIFF
--- a/.github/workflows/rebase-translations.yml
+++ b/.github/workflows/rebase-translations.yml
@@ -4,7 +4,7 @@
 # When a translation PR is merged, this workflow automatically rebases the
 # other open translation PRs against the updated main branch. It covers both
 # kinds this tool creates: `translation-sync-*` branches from the Action's sync
-# mode, and `resync/*` branches from the CLI's `forward --github`.
+# mode, and `resync/*` branches from the CLI's `translate forward --github`.
 #
 # This eliminates merge conflicts caused by multiple upstream PRs
 # modifying the same files. See: https://github.com/QuantEcon/action-translation/issues/63
@@ -20,7 +20,7 @@ on:
 jobs:
   rebase:
     # Only run when a translation PR is merged. Both prefixes must be listed:
-    # sync mode creates `translation-sync-*`, while the CLI's `forward --github`
+    # sync mode creates `translation-sync-*`, while the CLI's `translate forward --github`
     # creates `resync/*`, and a wave of resync PRs goes stale the same way.
     # Keep this in step with `isTranslationBranch` in the action's src/branch-naming.ts
     # — this `if` decides whether the job runs, that predicate decides which open PRs

--- a/.github/workflows/rebase-translations.yml
+++ b/.github/workflows/rebase-translations.yml
@@ -1,8 +1,10 @@
 # Rebase Translation PRs
 #
 # Install this workflow in the TARGET (translated) repository.
-# When a translation-sync PR is merged, this workflow automatically
-# rebases other open translation-sync PRs against the updated main branch.
+# When a translation PR is merged, this workflow automatically rebases the
+# other open translation PRs against the updated main branch. It covers both
+# kinds this tool creates: `translation-sync-*` branches from the Action's sync
+# mode, and `resync/*` branches from the CLI's `forward --github`.
 #
 # This eliminates merge conflicts caused by multiple upstream PRs
 # modifying the same files. See: https://github.com/QuantEcon/action-translation/issues/63
@@ -17,10 +19,16 @@ on:
 
 jobs:
   rebase:
-    # Only run when a translation-sync PR is merged
+    # Only run when a translation PR is merged. Both prefixes must be listed:
+    # sync mode creates `translation-sync-*`, while the CLI's `forward --github`
+    # creates `resync/*`, and a wave of resync PRs goes stale the same way.
+    # Keep this in step with `isTranslationBranch` in the action's src/branch-naming.ts
+    # — this `if` decides whether the job runs, that predicate decides which open PRs
+    # it then rebases, so a prefix matching only one of them is a no-op run.
     if: >
       github.event.pull_request.merged == true &&
-      startsWith(github.event.pull_request.head.ref, 'translation-sync-')
+      (startsWith(github.event.pull_request.head.ref, 'translation-sync-') ||
+       startsWith(github.event.pull_request.head.ref, 'resync/'))
     runs-on: ubuntu-latest
 
     permissions:


### PR DESCRIPTION
Brings this repo's rebase workflow in step with the upstream template as of [action-translation v0.18.1](https://github.com/QuantEcon/action-translation/releases/tag/v0.18.1).

## Why the engine fix alone was not enough

The rebase workflow only fired for `translation-sync-*` branches, which the Action's sync mode creates. The CLI's `translate forward --github` creates `resync/{stem}` branches — so merging one resync PR never rebased its siblings. During a drift-recovery wave that leaves a stack of open PRs whose bases go stale with every merge, each re-enqueued by hand. Observed on the 69-PR `lecture-python.zh-cn` Track B wave.

That was fixed engine-side in v0.18.1 ([#121](https://github.com/QuantEcon/action-translation/pull/121), closing [#115](https://github.com/QuantEcon/action-translation/issues/115)) — but the prefix turned out to be enforced in **three** places, and this workflow `if` is one of them. It gates whether the job runs at all, and it runs *before* the action does. So a repo can be pinned `@v0`, pick up the engine fix automatically, and still never rebase a resync PR, because the job never starts.

Both layers must list both prefixes. This PR is the workflow half.

## Verification status

Per the harness-first policy, this is **staged but should not merge until the fix is validated end-to-end on the `test-translation-sync` harness**. The rebase path has never been exercised end-to-end, and the original defect was invisible precisely because its failure mode is silence — a job that skips looks identical to a job with nothing to do.

Part of Stage 1 follow-up; see QuantEcon/project-translation#9.

🤖 Generated with [Claude Code](https://claude.com/claude-code)