### PR TITLE
[action-translation] resync: wealth_dynamics.md

### DIFF
--- a/.translate/state/wealth_dynamics.md.yml
+++ b/.translate/state/wealth_dynamics.md.yml
@@ -1,6 +1,6 @@
-source-sha: 39b39c9bcb4363353b27e2180f12551fbd3a6e9f
-synced-at: "2026-07-18"
+source-sha: fccf5a9fd50129b3b03a4fd7b5d04976ac51e3a5
+synced-at: "2026-07-21"
 model: claude-sonnet-5
 mode: RESYNC
 section-count: 6
-tool-version: 0.17.0
+tool-version: 0.20.0

--- a/lectures/wealth_dynamics.md
+++ b/lectures/wealth_dynamics.md
@@ -109,12 +109,15 @@ from numba.experimental import jitclass
 
 上面已经导入的[QuantEcon.py](https://github.com/QuantEcon/QuantEcon.py)包含了计算洛伦兹曲线的函数。
 
-举例说明，假设以下数据代表了10,000个家庭的财富分布
+举例说明，假设
 
 ```{code-cell} ipython3
+rng = np.random.default_rng()
 n = 10_000                      # 样本大小
-w = np.exp(np.random.randn(n))  # 生成对数正态分布的随机样本
+w = np.exp(rng.standard_normal(n))  # 生成对数正态分布的随机样本
 ```
+
+是代表10,000个家庭财富的数据。
 
 我们可以按如下方式计算并绘制洛伦兹曲线：
 
@@ -147,7 +150,7 @@ a_vals = (1, 2, 5)              # 帕累托分布的尾部指数
 n = 10_000                      # 每个样本的大小
 fig, ax = plt.subplots()
 for a in a_vals:
-    u = np.random.uniform(size=n)
+    u = rng.uniform(size=n)
     y = u**(-1/a)               # 服从尾部指数为a的帕累托分布
     f_vals, l_vals = qe.lorenz_curve(y)
     ax.plot(f_vals, l_vals, label=f'$a = {a}$')
@@ -184,7 +187,7 @@ n = 100
 
 fig, ax = plt.subplots()
 for a in a_vals:
-    y = np.random.weibull(a, size=n)
+    y = rng.weibull(a, size=n)
     ginis.append(qe.gini_coefficient(y))
     ginis_theoretical.append(1 - 2**(-1/a))
 ax.plot(a_vals, ginis, label='基尼系数估值')
@@ -543,13 +546,14 @@ plt.show()
 这是一个解法，它在理论和模拟之间产生了很好的匹配。
 
 ```{code-cell} ipython3
+rng = np.random.default_rng()
 a_vals = np.linspace(1, 10, 25)  # 帕累托尾部指数
 ginis = np.empty_like(a_vals)
 
 n = 1000                         # 每个样本的大小
 fig, ax = plt.subplots()
 for i, a in enumerate(a_vals):
-    y = np.random.uniform(size=n)**(-1/a)
+    y = rng.uniform(size=n)**(-1/a)
     ginis[i] = qe.gini_coefficient(y)
 ax.plot(a_vals, ginis, label='抽样值')
 ax.plot(a_vals, 1/(2*a_vals - 1), label='理论值')


### PR DESCRIPTION
## Forward Resync: wealth_dynamics.md

**Source**: [QuantEcon/lecture-python.myst](https://github.com/QuantEcon/lecture-python.myst) — [lectures/wealth_dynamics.md](https://github.com/QuantEcon/lecture-python.myst/blob/main/lectures/wealth_dynamics.md)
**Source commit**: [`fccf5a9`](https://github.com/QuantEcon/lecture-python.myst/commit/fccf5a9fd50129b3b03a4fd7b5d04976ac51e3a5)
This PR resyncs the translation to match the current source document.

**Reason**: Target adds font configuration lines (mpl font manager, Source Han Serif SC setup, figure size setting) in the imports code cell that are not present in source. Also, target uses np.random.default_rng() replaced with np.random.randn()/np.random.uniform() in several code cells (a code logic difference, not just style), and drops the 'rng = np.random.default_rng()' line in some places while source consistently uses the rng object. These are substantive code differences, but the primary addition (font/plot config block) is content added in target not in source, so TARGET_HAS_ADDITIONS takes priority.

### Changes

Whole-file resync applied. The entire document was resynced in a single pass.

---
*Created by [action-translation](https://github.com/QuantEcon/action-translation) forward resync*

<!-- translation-sync-metadata
{
  "sourceRepo": "QuantEcon/lecture-python.myst",
  "sourcePR": 0,
  "mode": "resync",
  "sourceCommitSha": "fccf5a9fd50129b3b03a4fd7b5d04976ac51e3a5",
  "targetBaseSha": "ada5ab550457bdd11017c19719623732b5f297b1",
  "sourceLanguage": "en",
  "targetLanguage": "zh-cn",
  "claudeModel": "claude-sonnet-5",
  "files": [
    {
      "path": "lectures/wealth_dynamics.md",
      "type": "markdown"
    },
    {
      "path": ".translate/state/wealth_dynamics.md.yml"
    }
  ]
}
-->