### PR TITLE
Seed batch 1: five missing lectures (Opus 4.8 calibration batch)

### DIFF
--- a/.translate/config.yml
+++ b/.translate/config.yml
@@ -1,0 +1,4 @@
+source-language: en
+target-language: zh-cn
+docs-folder: lectures
+tool-version: 0.20.0

--- a/.translate/state/blackwell_kihlstrom.md.yml
+++ b/.translate/state/blackwell_kihlstrom.md.yml
@@ -1,0 +1,6 @@
+source-sha: fea6b58cd64d8502f8e09821f63ae7a6f890cc44
+synced-at: "2026-07-21"
+model: claude-opus-4-8
+mode: NEW
+section-count: 13
+tool-version: 0.20.0

--- a/.translate/state/chow_business_cycles.md.yml
+++ b/.translate/state/chow_business_cycles.md.yml
@@ -1,0 +1,6 @@
+source-sha: 78030a3a27f6527046675bcd8a8d27995ca25af6
+synced-at: "2026-07-21"
+model: claude-opus-4-8
+mode: NEW
+section-count: 10
+tool-version: 0.20.0

--- a/.translate/state/information_market_equilibrium.md.yml
+++ b/.translate/state/information_market_equilibrium.md.yml
@@ -1,0 +1,6 @@
+source-sha: 78030a3a27f6527046675bcd8a8d27995ca25af6
+synced-at: "2026-07-21"
+model: claude-opus-4-8
+mode: NEW
+section-count: 7
+tool-version: 0.20.0

--- a/.translate/state/merging_of_opinions.md.yml
+++ b/.translate/state/merging_of_opinions.md.yml
@@ -1,0 +1,6 @@
+source-sha: a8966965b2649d470ea144150ca5fd5d520b5345
+synced-at: "2026-07-21"
+model: claude-opus-4-8
+mode: NEW
+section-count: 11
+tool-version: 0.20.0

--- a/.translate/state/survival_recursive_preferences.md.yml
+++ b/.translate/state/survival_recursive_preferences.md.yml
@@ -1,0 +1,6 @@
+source-sha: 78030a3a27f6527046675bcd8a8d27995ca25af6
+synced-at: "2026-07-21"
+model: claude-opus-4-8
+mode: NEW
+section-count: 14
+tool-version: 0.20.0

--- a/lectures/_static/quant-econ.bib
+++ b/lectures/_static/quant-econ.bib
@@ -1,7 +1,876 @@
-###
-QuantEcon Bibliography File used in conjuction with sphinxcontrib-bibtex package
-Note: Extended Information (like abstracts, doi, url's etc.) can be found in quant-econ-extendedinfo.bib file in _static/
-###
+@article{BreedenLitzenberger1978,
+  author    = {Breeden, Douglas T. and Litzenberger, Robert H.},
+  title     = {Prices of State-Contingent Claims Implicit in Option Prices},
+  journal   = {Journal of Business},
+  volume    = {51},
+  number    = {4},
+  pages     = {621--651},
+  year      = {1978},
+  doi       = {10.1086/296025}
+}
+
+@article{CarrYu2012,
+  author    = {Carr, Peter and Yu, Jiming},
+  title     = {Risk, Return, and {Ross} Recovery},
+  journal   = {Journal of Derivatives},
+  volume    = {20},
+  number    = {1},
+  pages     = {38--59},
+  year      = {2012},
+  doi       = {10.3905/jod.2012.20.1.038}
+}
+
+@article{BlackScholes1973,
+  author    = {Black, Fischer and Scholes, Myron},
+  title     = {The Pricing of Options and Corporate Liabilities},
+  journal   = {Journal of Political Economy},
+  volume    = {81},
+  number    = {3},
+  pages     = {637--654},
+  year      = {1973},
+  doi       = {10.1086/260062}
+}
+
+@article{Merton1973,
+  author    = {Merton, Robert C.},
+  title     = {Theory of Rational Option Pricing},
+  journal   = {Bell Journal of Economics and Management Science},
+  volume    = {4},
+  number    = {1},
+  pages     = {141--183},
+  year      = {1973},
+  doi       = {10.2307/3003143}
+}
+
+@article{CoxRossRubinstein1979,
+  author    = {Cox, John C. and Ross, Stephen A. and Rubinstein, Mark},
+  title     = {Option Pricing: A Simplified Approach},
+  journal   = {Journal of Financial Economics},
+  volume    = {7},
+  number    = {3},
+  pages     = {229--263},
+  year      = {1979},
+  doi       = {10.1016/0304-405X(79)90015-1}
+}
+
+@article{JackwerthRubinstein1996,
+  author    = {Jackwerth, Jens Carsten and Rubinstein, Mark},
+  title     = {Recovering Probability Distributions from Option Prices},
+  journal   = {Journal of Finance},
+  volume    = {51},
+  number    = {5},
+  pages     = {1611--1631},
+  year      = {1996},
+  doi       = {10.1111/j.1540-6261.1996.tb05219.x}
+}
+
+@article{Weitzman2007,
+  author    = {Weitzman, Martin L.},
+  title     = {Subjective Expectations and Asset-Return Puzzles},
+  journal   = {American Economic Review},
+  volume    = {97},
+  number    = {4},
+  pages     = {1102--1130},
+  year      = {2007},
+  doi       = {10.1257/aer.97.4.1102}
+}
+
+@article{BorovickaHansenScheinkman2016,
+  author    = {Borovička, Jaroslav and Hansen, Lars Peter and Scheinkman, José A.},
+  title     = {Misspecified Recovery},
+  journal   = {Journal of Finance},
+  volume    = {71},
+  number    = {6},
+  pages     = {2493--2544},
+  year      = {2016},
+  doi       = {10.1111/jofi.12404}
+}
+
+@article{Ross2015,
+  author    = {Ross, Stephen A.},
+  title     = {The Recovery Theorem},
+  journal   = {Journal of Finance},
+  volume    = {70},
+  number    = {2},
+  pages     = {615--648},
+  year      = {2015},
+  doi       = {10.1111/jofi.12092}
+}
+
+@article{HansenScheinkman2009,
+  author    = {Hansen, Lars Peter and Scheinkman, José A.},
+  title     = {Long-Term Risk: An Operator Approach},
+  journal   = {Econometrica},
+  volume    = {77},
+  number    = {1},
+  pages     = {177--234},
+  year      = {2009},
+  doi       = {10.3982/ECTA6761}
+}
+
+@article{AlvarezJermann2005,
+  author    = {Alvarez, Fernando and Jermann, Urban J.},
+  title     = {Using Asset Prices to Measure the Persistence of the Marginal Utility of Wealth},
+  journal   = {Econometrica},
+  volume    = {73},
+  number    = {6},
+  pages     = {1977--2016},
+  year      = {2005},
+  doi       = {10.1111/j.1468-0262.2005.00643.x}
+}
+
+@article{BakshiChabiYo2012,
+  author    = {Bakshi, Gurdip and Chabi-Yo, Fousseni},
+  title     = {Variance Bounds on the Permanent and Transitory Components of Stochastic Discount Factors},
+  journal   = {Journal of Financial Economics},
+  volume    = {105},
+  number    = {1},
+  pages     = {191--208},
+  year      = {2012},
+  doi       = {10.1016/j.jfineco.2012.01.003}
+}
+
+@article{BackusGregoryZin1989,
+  author    = {Backus, David K. and Gregory, Allan W. and Zin, Stanley E.},
+  title     = {Risk Premiums in the Term Structure: Evidence from Artificial Economies},
+  journal   = {Journal of Monetary Economics},
+  volume    = {24},
+  number    = {3},
+  pages     = {371--399},
+  year      = {1989},
+  doi       = {10.1016/0304-3932(89)90027-5}
+}
+
+@article{Hansen2012,
+  author    = {Hansen, Lars Peter},
+  title     = {Dynamic Valuation Decomposition within Stochastic Economies},
+  journal   = {Econometrica},
+  volume    = {80},
+  number    = {3},
+  pages     = {911--967},
+  year      = {2012},
+  note      = {Fisher--Schultz Lecture},
+  doi       = {10.3982/ECTA8070}
+}
+
+@article{BackusChernovZin2014,
+  author    = {Backus, David K. and Chernov, Mikhail and Zin, Stanley E.},
+  title     = {Sources of Entropy in Representative Agent Models},
+  journal   = {Journal of Finance},
+  volume    = {69},
+  number    = {1},
+  pages     = {51--99},
+  year      = {2014},
+  doi       = {10.1111/jofi.12090}
+}
+
+@article{Borovicka2020,
+  author    = {Borovička, Jaroslav},
+  title     = {Survival and Long-Run Dynamics with Heterogeneous Beliefs under Recursive Preferences},
+  journal   = {Journal of Political Economy},
+  volume    = {128},
+  number    = {1},
+  pages     = {206--251},
+  year      = {2020},
+  publisher = {University of Chicago Press},
+  doi       = {10.1086/704072}
+}
+
+@article{Sandroni2000Markets,
+  author    = {Sandroni, Alvaro},
+  title     = {Do Markets Favor Agents Able to Make Accurate Predictions?},
+  journal   = {Econometrica},
+  volume    = {68},
+  number    = {6},
+  pages     = {1303--1341},
+  year      = {2000}
+}
+
+@article{Blume_Easley2006,
+  author    = {Blume, Lawrence and Easley, David},
+  title     = {If You're So Smart, Why Aren't You Rich? {B}elief Selection in Complete and Incomplete Markets},
+  journal   = {Econometrica},
+  volume    = {74},
+  number    = {4},
+  pages     = {929--966},
+  year      = {2006}
+}
+
+@article{Epstein_Zin1989,
+  author    = {Epstein, Larry G. and Zin, Stanley E.},
+  title     = {Substitution, Risk Aversion, and the Temporal Behavior of Consumption and Asset Returns: A Theoretical Framework},
+  journal   = {Econometrica},
+  volume    = {57},
+  number    = {4},
+  pages     = {937--969},
+  year      = {1989},
+  doi       = {10.2307/1913778}
+}
+
+@article{Epstein_Zin1991,
+  author    = {Epstein, Larry G. and Zin, Stanley E.},
+  title     = {Substitution, Risk Aversion, and the Temporal Behavior of Consumption and Asset Returns: An Empirical Analysis},
+  journal   = {Journal of Political Economy},
+  volume    = {99},
+  number    = {2},
+  pages     = {263--286},
+  year      = {1991},
+  doi       = {10.1086/261750}
+}
+
+@article{Duffie_Epstein1992a,
+  author    = {Duffie, Darrell and Epstein, Larry G.},
+  title     = {Stochastic Differential Utility},
+  journal   = {Econometrica},
+  volume    = {60},
+  number    = {2},
+  pages     = {353--394},
+  year      = {1992}
+}
+
+@article{Dumas_Uppal_Wang2000,
+  author    = {Dumas, Bernard and Uppal, Raman and Wang, Tan},
+  title     = {Efficient Intertemporal Allocations with Recursive Utility},
+  journal   = {Journal of Economic Theory},
+  volume    = {93},
+  number    = {2},
+  pages     = {154--183},
+  year      = {2000}
+}
+
+@article{DeLong_etal1991,
+  author    = {De Long, J. Bradford and Shleifer, Andrei and Summers, Lawrence H. and Waldmann, Robert J.},
+  title     = {The Survival of Noise Traders in Financial Markets},
+  journal   = {Journal of Business},
+  volume    = {64},
+  number    = {1},
+  pages     = {1--19},
+  year      = {1991}
+}
+
+@article{Blume_Easley1992,
+  author    = {Blume, Lawrence and Easley, David},
+  title     = {Evolution and Market Behavior},
+  journal   = {Journal of Economic Theory},
+  volume    = {58},
+  number    = {1},
+  pages     = {9--40},
+  year      = {1992}
+}
+
+@article{Yan2008,
+  author    = {Yan, Hongjun},
+  title     = {Natural Selection in Financial Markets: Does It Work?},
+  journal   = {Management Science},
+  volume    = {54},
+  number    = {11},
+  pages     = {1935--1950},
+  year      = {2008}
+}
+
+@article{Kogan_etal2006,
+  author    = {Kogan, Leonid and Ross, Stephen A. and Wang, Jiang and Westerfield, Mark M.},
+  title     = {The Price Impact and Survival of Irrational Traders},
+  journal   = {Journal of Finance},
+  volume    = {61},
+  number    = {1},
+  pages     = {195--229},
+  year      = {2006}
+}
+
+@article{Kogan_etal2017,
+  author    = {Kogan, Leonid and Ross, Stephen A. and Wang, Jiang and Westerfield, Mark M.},
+  title     = {Market Selection},
+  journal   = {Journal of Economic Theory},
+  volume    = {168},
+  pages     = {209--236},
+  year      = {2017}
+}
+
+@article{Kreps_Porteus1978,
+  author    = {Kreps, David M. and Porteus, Evan L.},
+  title     = {Temporal Resolution of Uncertainty and Dynamic Choice Theory},
+  journal   = {Econometrica},
+  volume    = {46},
+  number    = {1},
+  pages     = {185--200},
+  year      = {1978},
+  doi       = {10.2307/1913656}
+}
+
+@article{Lucas_Stokey1984,
+  author    = {Lucas, Robert E. and Stokey, Nancy L.},
+  title     = {Optimal Growth with Many Consumers},
+  journal   = {Journal of Economic Theory},
+  volume    = {32},
+  number    = {1},
+  pages     = {139--171},
+  year      = {1984},
+  doi       = {10.1016/0022-0531(84)90079-6}
+}
+
+@book{Karlin_Taylor1981,
+  author    = {Karlin, Samuel and Taylor, Howard M.},
+  title     = {A Second Course in Stochastic Processes},
+  publisher = {Academic Press},
+  year      = {1981}
+}
+
+@article{Brunnermeier_etal2014,
+  author    = {Brunnermeier, Markus K. and Simsek, Alp and Xiong, Wei},
+  title     = {A Welfare Criterion for Models with Distorted Beliefs},
+  journal   = {Quarterly Journal of Economics},
+  volume    = {129},
+  number    = {4},
+  pages     = {1753--1797},
+  year      = {2014}
+}
+
+@article{Feller1952,
+  author    = {Feller, William},
+  title     = {The Parabolic Differential Equations and the Associated Semi-Groups of Transformations},
+  journal   = {Annals of Mathematics},
+  volume    = {55},
+  number    = {3},
+  pages     = {468--519},
+  year      = {1952}
+}
+
+@article{Geoffard1996,
+  author    = {Geoffard, Pierre-Yves},
+  title     = {Discounting and Optimizing: Capital Accumulation Problems as Variational Minmax Problems},
+  journal   = {Journal of Economic Theory},
+  volume    = {69},
+  number    = {1},
+  pages     = {53--70},
+  year      = {1996}
+}
+
+@article{Garleanu_Panageas2015,
+  author    = {Gârleanu, Nicolae and Panageas, Stavros},
+  title     = {Young, Old, Conservative, and Bold: The Implications of Heterogeneity and Finite Lives for Asset Pricing},
+  journal   = {Journal of Political Economy},
+  volume    = {123},
+  number    = {3},
+  pages     = {670--685},
+  year      = {2015}
+}
+
+@article{Negishi1960,
+  author    = {Negishi, Takashi},
+  title     = {Welfare Economics and Existence of an Equilibrium for a Competitive Economy},
+  journal   = {Metroeconomica},
+  volume    = {12},
+  number    = {2--3},
+  pages     = {92--97},
+  year      = {1960}
+}
+
+@article{MillerSanchirico1999,
+  author    = {Miller, Ronald I. and Sanchirico, Chris William},
+  title     = {The Role of Absolute Continuity in
+               ``{Merging} of {Opinions}'' and
+               ``{Rational} {Learning}''},
+  journal   = {Games and Economic Behavior},
+  year      = {1999},
+  volume    = {29},
+  number    = {1--2},
+  pages     = {170--190},
+  doi       = {10.1006/game.1999.0752}
+}
+
+@article{JacksonKalaiSmorodinsky1999,
+  author    = {Jackson, Matthew O. and Kalai, Ehud and
+               Smorodinsky, Rann},
+  title     = {Bayesian Representation of Stochastic Processes
+               under Learning: {de Finetti} Revisited},
+  journal   = {Econometrica},
+  year      = {1999},
+  volume    = {67},
+  number    = {4},
+  pages     = {875--893},
+  doi       = {10.1111/1468-0262.00055}
+}
+
+@article{KalaiLehrer1993Nash,
+  author    = {Kalai, Ehud and Lehrer, Ehud},
+  title     = {Rational Learning Leads to {Nash} Equilibrium},
+  journal   = {Econometrica},
+  year      = {1993},
+  volume    = {61},
+  number    = {5},
+  pages     = {1019--1045},
+  doi       = {10.2307/2951492}
+}
+
+@article{KalaiLehrer1993Subjective,
+  author    = {Kalai, Ehud and Lehrer, Ehud},
+  title     = {Subjective Equilibrium in Repeated Games},
+  journal   = {Econometrica},
+  year      = {1993},
+  volume    = {61},
+  number    = {5},
+  pages     = {1231--1240},
+  doi       = {10.2307/2951500}
+}
+
+@article{KalaiLehrer1994Merging,
+  author    = {Kalai, Ehud and Lehrer, Ehud},
+  title     = {Weak and Strong Merging of Opinions},
+  journal   = {Journal of Mathematical Economics},
+  year      = {1994},
+  volume    = {23},
+  number    = {1},
+  pages     = {73--86},
+  doi       = {10.1016/0304-4068(94)90037-X}
+}
+
+@article{KalaiLehrerSmorodinsky1999,
+  author    = {Kalai, Ehud and Lehrer, Ehud and Smorodinsky, Rann},
+  title     = {Calibrated Forecasting and Merging},
+  journal   = {Games and Economic Behavior},
+  year      = {1999},
+  volume    = {29},
+  number    = {1--2},
+  pages     = {151--169},
+  doi       = {10.1006/game.1998.0608}
+}
+
+@article{Sandroni1998Nash,
+  author    = {Sandroni, Alvaro},
+  title     = {Necessary and Sufficient Conditions for
+               Convergence to {Nash} Equilibrium:
+               The Almost Absolute Continuity Hypothesis},
+  journal   = {Games and Economic Behavior},
+  year      = {1998},
+  volume    = {22},
+  number    = {1},
+  pages     = {121--147},
+  doi       = {10.1006/game.1997.0572}
+}
+
+@article{PomattoAlNajjarSandroni2014,
+  author    = {Pomatto, Luciano and Al-Najjar, Nabil I. and
+               Sandroni, Alvaro},
+  title     = {Merging and Testing Opinions},
+  journal   = {The Annals of Statistics},
+  year      = {2014},
+  volume    = {42},
+  number    = {3},
+  pages     = {1003--1028},
+  doi       = {10.1214/14-AOS1212}
+}
+
+@article{LehrerSmorodinsky1996Compatible,
+  author    = {Lehrer, Ehud and Smorodinsky, Rann},
+  title     = {Compatible Measures and Merging},
+  journal   = {Mathematics of Operations Research},
+  year      = {1996},
+  volume    = {21},
+  number    = {3},
+  pages     = {697--706},
+  doi       = {10.1287/moor.21.3.697}
+}
+
+@incollection{LehrerSmorodinsky1996Learning,
+  author    = {Lehrer, Ehud and Smorodinsky, Rann},
+  title     = {Merging and Learning},
+  booktitle = {Statistics, Probability and Game Theory:
+               Papers in Honor of {David Blackwell}},
+  editor    = {Ferguson, Thomas S. and Shapley, Lloyd S. and
+               MacQueen, James B.},
+  series    = {{IMS} Lecture Notes -- Monograph Series},
+  volume    = {30},
+  pages     = {147--168},
+  publisher = {Institute of Mathematical Statistics},
+  address   = {Hayward, CA},
+  year      = {1996},
+  doi       = {10.1214/lnms/1215453571}
+}
+
+@article{Nyarko1994,
+  author    = {Nyarko, Yaw},
+  title     = {Bayesian Learning Leads to Correlated Equilibria
+               in Normal Form Games},
+  journal   = {Economic Theory},
+  year      = {1994},
+  volume    = {4},
+  number    = {6},
+  pages     = {821--841},
+  doi       = {10.1007/BF01213814}
+}
+
+@article{JacksonKalai1999,
+  author    = {Jackson, Matthew O. and Kalai, Ehud},
+  title     = {Reputation versus Social Learning},
+  journal   = {Journal of Economic Theory},
+  year      = {1999},
+  volume    = {88},
+  number    = {1},
+  pages     = {40--59},
+  doi       = {10.1006/jeth.1999.2538}
+}
+
+@article{AcemogluChernozhukovYildiz2016,
+  author    = {Acemoglu, Daron and Chernozhukov, Victor and
+               Yildiz, Muhamet},
+  title     = {Fragility of Asymptotic Agreement under
+               {Bayesian} Learning},
+  journal   = {Theoretical Economics},
+  year      = {2016},
+  volume    = {11},
+  number    = {1},
+  pages     = {187--225},
+  doi       = {10.3982/TE436}
+}
+
+@article{DiaconisFreedman1986,
+  author    = {Diaconis, Persi and Freedman, David},
+  title     = {On the Consistency of {Bayes} Estimates},
+  journal   = {The Annals of Statistics},
+  year      = {1986},
+  volume    = {14},
+  number    = {1},
+  pages     = {1--26},
+  doi       = {10.1214/aos/1176349830}
+}
+
+@article{lucas1967adjustment,
+  title={Adjustment costs and the theory of supply},
+  author={Lucas Jr, Robert E},
+  journal={Journal of political economy},
+  volume={75},
+  number={4, Part 1},
+  pages={321--334},
+  year={1967},
+  publisher={The University of Chicago Press}
+}
+
+@article{Prescott_Visscher_1980,
+  author    = {Prescott, Edward C. and Visscher, Michael},
+  title     = {Organization Capital},
+  journal   = {Journal of Political Economy},
+  volume    = {88},
+  number    = {3},
+  pages     = {446--461},
+  year      = {1980},
+  publisher = {University of Chicago Press}
+}
+
+@article{Coase_1937,
+  author    = {Coase, Ronald H.},
+  title     = {The Nature of the Firm},
+  journal   = {Economica},
+  volume    = {4},
+  number    = {16},
+  pages     = {386--405},
+  year      = {1937}
+}
+
+@book{Williamson_1975,
+  author    = {Williamson, Oliver E.},
+  title     = {Markets and Hierarchies: Analysis and Antitrust Implications},
+  publisher = {Free Press},
+  address   = {New York},
+  year      = {1975}
+}
+
+@article{Lucas_Prescott_1971,
+  author    = {Lucas, Robert E., Jr. and Prescott, Edward C.},
+  title     = {Investment under Uncertainty},
+  journal   = {Econometrica},
+  volume    = {39},
+  number    = {5},
+  pages     = {659--681},
+  year      = {1971}
+}
+
+@article{Stigler_1958,
+  author    = {Stigler, George J.},
+  title     = {The Economies of Scale},
+  journal   = {Journal of Law and Economics},
+  volume    = {1},
+  pages     = {54--71},
+  year      = {1958}
+}
+
+@book{Becker_1975,
+  author    = {Becker, Gary S.},
+  title     = {Human Capital: A Theoretical and Empirical Analysis, with Special Reference to Education},
+  edition   = {2nd},
+  publisher = {National Bureau of Economic Research},
+  address   = {New York},
+  year      = {1975}
+}
+
+@article{Mansfield_1962,
+  author    = {Mansfield, Edwin},
+  title     = {Entry, {G}ibrat's Law, Innovation, and the Growth of Firms},
+  journal   = {American Economic Review},
+  volume    = {52},
+  number    = {5},
+  pages     = {1023--1051},
+  year      = {1962}
+}
+
+@article{Hymer_Pashigian_1962,
+  author    = {Hymer, Stephen and Pashigian, Peter},
+  title     = {Firm Size and Rate of Growth},
+  journal   = {Journal of Political Economy},
+  volume    = {70},
+  number    = {6},
+  pages     = {556--569},
+  year      = {1962}
+}
+
+@article{blackwell1962,
+  author    = {Blackwell, David and Dubins, Lester E.},
+  title     = {Merging of Opinions with Increasing Information},
+  journal   = {Annals of Mathematical Statistics},
+  year      = {1962},
+  volume    = {33},
+  number    = {3},
+  pages     = {882--886},
+}
+
+@article{aumann1976,
+  author    = {Aumann, Robert J.},
+  title     = {Agreeing to Disagree},
+  journal   = {Annals of Statistics},
+  year      = {1976},
+  volume    = {4},
+  number    = {6},
+  pages     = {1236--1239},
+}
+
+@book{doob1953,
+  author    = {Doob, Joseph L.},
+  title     = {Stochastic Processes},
+  publisher = {Wiley},
+  address   = {New York},
+  year      = {1953},
+}
+
+@article{kakutani1948,
+  author    = {Kakutani, Shizuo},
+  title     = {On Equivalence of Infinite Product Measures},
+  journal   = {Annals of Mathematics},
+  year      = {1948},
+  volume    = {49},
+  number    = {1},
+  pages     = {214--224},
+}
+
+@article{girsanov1960,
+  author    = {Girsanov, Igor V.},
+  title     = {On Transforming a Certain Class of Stochastic Processes
+               by Absolutely Continuous Substitution of Measures},
+  journal   = {Theory of Probability and Its Applications},
+  year      = {1960},
+  volume    = {5},
+  number    = {3},
+  pages     = {285--301},
+}
+
+@article{novikov1972,
+  author    = {Novikov, Alexander A.},
+  title     = {On an Identity for Stochastic Integrals},
+  journal   = {Theory of Probability and Its Applications},
+  year      = {1972},
+  volume    = {17},
+  number    = {4},
+  pages     = {717--720},
+}
+
+@inproceedings{blackwell1951,
+  author    = {Blackwell, David},
+  title     = {Comparison of Experiments},
+  booktitle = {Proceedings of the Second {Berkeley} Symposium on Mathematical
+               Statistics and Probability},
+  editor    = {Neyman, Jerzy},
+  pages     = {93--102},
+  year      = {1951},
+  publisher = {University of California Press},
+  address   = {Berkeley, CA}
+}
+
+@article{blackwell1953,
+  author    = {Blackwell, David},
+  title     = {Equivalent Comparisons of Experiments},
+  journal   = {Annals of Mathematical Statistics},
+  volume    = {24},
+  number    = {2},
+  pages     = {265--272},
+  year      = {1953},
+  doi       = {10.1214/aoms/1177729032}
+}
+
+@techreport{bonnenblust1949,
+  author      = {Bohnenblust, H. F. and Shapley, Lloyd S. and Sherman, Seymour},
+  title       = {Reconnaissance in Game Theory},
+  institution = {The RAND Corporation},
+  number      = {RM-208},
+  year        = {1949},
+  address     = {Santa Monica, CA},
+  note        = {Cited for the economic criterion for comparing experiments}
+}
+
+@article{degroot1962,
+  author    = {{DeGroot}, Morris H.},
+  title     = {Uncertainty, Information, and Sequential Experiments},
+  journal   = {Annals of Mathematical Statistics},
+  volume    = {33},
+  number    = {2},
+  pages     = {404--419},
+  year      = {1962},
+  doi       = {10.1214/aoms/1177704567}
+}
+
+@incollection{kihlstrom1984,
+  author    = {Kihlstrom, Richard E.},
+  title     = {A {Bayesian} Exposition of {Blackwell}'s Theorem on the
+               Comparison of Experiments},
+  booktitle = {Bayesian Models in Economic Theory},
+  editor    = {Boyer, Marcel and Kihlstrom, Richard E.},
+  series    = {Studies in Bayesian Econometrics},
+  volume    = {5},
+  pages     = {13--31},
+  year      = {1984},
+  publisher = {North-Holland},
+  address   = {Amsterdam}
+}
+
+@article{kihlstrom1974a,
+  author    = {Kihlstrom, Richard E.},
+  title     = {A General Theory of Demand for Information about Product Quality},
+  journal   = {Journal of Economic Theory},
+  volume    = {8},
+  number    = {4},
+  pages     = {413--439},
+  year      = {1974},
+  doi       = {10.1016/0022-0531(74)90019-2}
+}
+
+@inproceedings{hansen2004certainty,
+  title={Certainty equivalence and model uncertainty},
+  author={Hansen, Lars Peter and Sargent, Thomas J},
+  booktitle={Conference on Models and Monetary Policy: Research in the Tradition of Dale Henderson, Richard Porter, and Peter Tinsley (http://www. federalreserve. gov/events/conferences/mmp2004/pdf/hansensargent. pdf)},
+  year={2004}
+}
+
+@article{evans2005interview,
+  title={An interview with Thomas J. Sargent},
+  author={Evans, George W and Honkapohja, Seppo},
+  journal={Macroeconomic Dynamics},
+  volume={9},
+  number={4},
+  pages={561--583},
+  year={2005},
+  publisher={Cambridge University Press}
+}
+
+@article{hansen2014nobel,
+  title={Nobel lecture: Uncertainty outside and inside economic models},
+  author={Hansen, Lars Peter},
+  journal={Journal of Political Economy},
+  volume={122},
+  number={5},
+  pages={945--987},
+  year={2014},
+  publisher={University of Chicago Press Chicago, IL}
+}
+
+@book{Sargent_Stachurski_2025, 
+  place={Cambridge}, 
+  title={Dynamic Programming: Finite States}, 
+  publisher={Cambridge University Press}, 
+  author={Sargent, Thomas J. and Stachurski, John},
+  year={2025}
+}
+
+@book{Sargent_Stachurski_2024,
+  place={Cambridge},
+  series={Structural Analysis in the Social Sciences},
+  title={Economic Networks: Theory and Computation},
+  publisher={Cambridge University Press},
+  author={Sargent, Thomas J. and Stachurski, John},
+  year={2024}
+}
+
+@article{slutsky1937,
+  author  = {Slutzky, Eugen},
+  title   = {The Summation of Random Causes as the Source of Cyclic Processes},
+  journal = {Econometrica},
+  volume  = {5},
+  number  = {2},
+  pages   = {105--146},
+  year    = {1937},
+  doi     = {10.2307/1907241}
+}
+
+@incollection{frisch33,
+ author = {Ragnar Frisch},
+ booktitle = {Economic Essays in Honour of Gustav Cassel},
+ pages = {171--203},
+ publisher = {Allen and Unwin},
+ title = {Propagation Problems and Impulse Problems in Dynamic Economics},
+ year = {1933}
+}
+
+@article{harsanyi1968games,
+  title={Games with Incomplete Information Played by ``{B}ayesian'' Players, {I}--{III} Part {II}. {B}ayesian Equilibrium Points},
+  author={Harsanyi, John C.},
+  journal={Management Science},
+  volume={14},
+  number={5},
+  pages={320--334},
+  year={1968},
+  publisher={INFORMS}
+}
+
+@article{harsanyi1968games3,
+  title={Games with Incomplete Information Played by ``{B}ayesian'' Players, {I}--{III} Part {III}. {T}he Basic Probability Distribution of the Game},
+  author={Harsanyi, John C.},
+  journal={Management Science},
+  volume={14},
+  number={7},
+  pages={486--502},
+  year={1968},
+  publisher={INFORMS}
+}
+
+@article{harsanyi1967games,
+  title={Games with Incomplete Information Played by ``{B}ayesian'' Players, {I}--{III} Part {I}. {T}he Basic Model},
+  author={Harsanyi, John C.},
+  journal={Management Science},
+  volume={14},
+  number={3},
+  pages={159--182},
+  year={1967},
+  publisher={INFORMS}
+}
+
+@article{miller1977risk,
+  title={Risk, uncertainty, and divergence of opinion},
+  author={Miller, Edward M},
+  journal={The Journal of finance},
+  volume={32},
+  number={4},
+  pages={1151--1168},
+  year={1977},
+  publisher={JSTOR}
+}
+
+@article{jeffreys1946invariant,
+  title={An invariant form for the prior probability in estimation problems},
+  author={Jeffreys, Harold},
+  journal={Proceedings of the Royal Society of London. Series A. Mathematical and Physical Sciences},
+  volume={186},
+  number={1007},
+  pages={453--461},
+  year={1946},
+  publisher={The Royal Society London}
+}
 
 @article{blume2018case,
   title={A case for incomplete markets},
@@ -60,18 +929,6 @@ Note: Extended Information (like abstracts, doi, url's etc.) can be found in qua
   publisher={The University of Chicago Press}
 }
 
-
-@article{blume2006if,
-  title={If you're so smart, why aren't you rich? Belief selection in complete and incomplete markets},
-  author={Blume, Lawrence and Easley, David},
-  journal={Econometrica},
-  volume={74},
-  number={4},
-  pages={929--966},
-  year={2006},
-  publisher={Wiley Online Library}
-}
-
 @article{mendoza1998international,
   title={The international ramifications of tax reforms: supply-side economics in a global economy},
   author={Mendoza, Enrique G and Tesar, Linda L},
@@ -80,7 +937,6 @@ Note: Extended Information (like abstracts, doi, url's etc.) can be found in qua
   year={1998},
   publisher={JSTOR}
 }
-
 
 @book{intriligator2002mathematical,
   title={Mathematical optimization and economic theory},
@@ -108,6 +964,14 @@ Note: Extended Information (like abstracts, doi, url's etc.) can be found in qua
   address = {New York}
 }
 
+@book{lucas1981rational,
+  title={Rational expectations and econometric practice},
+  author={Lucas, Robert E and Sargent, Thomas J},
+  year={1981},
+  publisher={U of Minnesota Press},
+  address = {Minneapolis, Minnesota}
+}
+
 @article{Orcutt_Winokur_69,
   issn      = {00129682, 14680262},
   abstract  = {Monte Carlo techniques are used to study the first order autoregressive time series model with unknown level, slope, and error variance. The effect of lagged variables on inference, estimation, and prediction is described, using results from the classical normal linear regression model as a standard. In particular, use of the t and x^2 distributions as approximate sampling distributions is verified for inference concerning the level and residual error variance. Bias in the least squares estimate of the slope is measured, and two bias corrections are evaluated. Least squares chained prediction is studied, and attempts to measure the success of prediction and to improve on the least squares technique are discussed.},
@@ -120,6 +984,16 @@ Note: Extended Information (like abstracts, doi, url's etc.) can be found in qua
   urldate   = {2022-06-25},
   volume    = {37},
   year      = {1969}
+}
+
+@incollection{Hurwicz:1962,
+ address = {Stanford, CA},
+ author = {Hurwicz, Leonid},
+ booktitle = {Logic, Methodology and Philosophy of Science},
+ pages = {232-239},
+ publisher = {Stanford University Press},
+ title = {On the Structural Form of Interdependent Systems},
+ year = {1962}
 }
 
 @article{hurwicz1950least,
@@ -141,8 +1015,8 @@ Note: Extended Information (like abstracts, doi, url's etc.) can be found in qua
 }
 
 @book{Chadhuri_Mukerjee_88,
-  title     = {Randomized Response: Theory and Technique},
-  author    = {A Chadhuri and R Mukerjee},
+  title     = {Randomized Response: Theory and Techniques},
+  author    = {Chaudhuri, A. and Mukerjee, R.},
   year      = {1988},
   publisher = {Marcel Dekker},
   address   = {New York}
@@ -158,7 +1032,6 @@ Note: Extended Information (like abstracts, doi, url's etc.) can be found in qua
   year      = {1965},
   publisher = {Taylor \& Francis}
 }
-
 
 @article{ljungqvist1993unified,
   title     = {A unified approach to measures of privacy in randomized response models: A utilitarian perspective},
@@ -180,7 +1053,6 @@ Note: Extended Information (like abstracts, doi, url's etc.) can be found in qua
   publisher = {JSTOR}
 }
 
-
 @article{leysieffer1976respondent,
   title     = {Respondent jeopardy and optimal designs in randomized response models},
   author    = {Leysieffer, Frederick W and Warner, Stanley L},
@@ -191,7 +1063,6 @@ Note: Extended Information (like abstracts, doi, url's etc.) can be found in qua
   year      = {1976},
   publisher = {Taylor \& Francis}
 }
-
 
 @article{anderson1976estimation,
   title     = {Estimation of a proportion through randomized response},
@@ -224,7 +1095,6 @@ Note: Extended Information (like abstracts, doi, url's etc.) can be found in qua
   publisher = {Elsevier}
 }
 
-
 @article{greenberg1969unrelated,
   title     = {The unrelated question randomized response model: Theoretical framework},
   author    = {Greenberg, Bernard G and Abul-Ela, Abdel-Latif A and Simmons, Walt R and Horvitz, Daniel G},
@@ -247,8 +1117,6 @@ Note: Extended Information (like abstracts, doi, url's etc.) can be found in qua
   publisher = {Taylor \& Francis}
 }
 
-
-
 @article{schmid2010,
   title     = {Dynamic mode decomposition of numerical and experimental data},
   author    = {Schmid, Peter J},
@@ -258,7 +1126,6 @@ Note: Extended Information (like abstracts, doi, url's etc.) can be found in qua
   year      = {2010},
   publisher = {Cambridge University Press}
 }
-
 
 @article{apostolakis1990,
   title     = {The concept of probability in safety assessments of technological systems},
@@ -271,10 +1138,9 @@ Note: Extended Information (like abstracts, doi, url's etc.) can be found in qua
   publisher = {American Association for the Advancement of Science}
 }
 
-
 @unpublished{Greenfield_Sargent_1993,
-  author = {Moses A Greenfield and Thomas J Sargent},
-  title  = {A Probabilistic Analysis of a Catastrophic Transuranic Waste Hoise Accident at the WIPP},
+  author = {Greenfield, Moses A. and Sargent, Thomas J.},
+  title  = {A Probabilistic Analysis of a Catastrophic Transuranic Waste Hoist Accident at the WIPP},
   year   = {1993},
   month  = {June},
   note   = {Environmental Evaluation Group, Albuquerque, New Mexico},
@@ -291,8 +1157,6 @@ Note: Extended Information (like abstracts, doi, url's etc.) can be found in qua
   year    = {2018}
 }
 
-
-
 @article{Groves_73,
   author  = {Groves, T.},
   year    = {1973},
@@ -303,12 +1167,12 @@ Note: Extended Information (like abstracts, doi, url's etc.) can be found in qua
 }
 
 @article{Clarke_71,
-  author  = {Clarke, E.},
-  year    = { 1971},
+  author  = {Clarke, Edward H.},
+  year    = {1971},
   title   = {Multipart pricing of public goods},
   journal = {Public Choice},
-  volume  = {8},
-  pages   = {19-33}
+  volume  = {11},
+  pages   = {17--33}
 }
 
 @article{Vickrey_61,
@@ -319,9 +1183,6 @@ Note: Extended Information (like abstracts, doi, url's etc.) can be found in qua
   volume  = {16},
   pages   = {8-37}
 }
-
-
-
 
 @article{Phelan_Townsend_91,
   author   = {Christopher Phelan and Robert M. Townsend},
@@ -338,7 +1199,6 @@ Note: Extended Information (like abstracts, doi, url's etc.) can be found in qua
   url      = {https://ideas.repec.org/a/oup/restud/v58y1991i5p853-881..html}
 }
 
-
 @article{Spear_Srivastava_87,
   author   = {Stephen E. Spear and Sanjay Srivastava},
   title    = {{On Repeated Moral Hazard with Discounting}},
@@ -354,7 +1214,6 @@ Note: Extended Information (like abstracts, doi, url's etc.) can be found in qua
   url      = {https://ideas.repec.org/a/oup/restud/v54y1987i4p599-617..html}
 }
 
-
 @article{tu_Rowley,
   title   = {On dynamic mode decomposition: Theory and applications},
   author  = {Tu, J. H. and Rowley, C. W. and Luchtenburg, D. M. and Brunton, S. L. and Kutz, J. N.},
@@ -365,26 +1224,20 @@ Note: Extended Information (like abstracts, doi, url's etc.) can be found in qua
   pages   = {391--421}
 }
 
-
 @book{Knight:1921,
   author        = {Knight, Frank H.},
-  date-added    = {2020-08-20 10:29:34 -0500},
-  date-modified = {2020-08-20 11:10:35 -0500},
   keywords      = {climate,modeling},
   publisher     = {Houghton Mifflin},
   title         = {{Risk, Uncertainty, and Profit}},
   year          = {1921}
 }
 
-
 @article{MaccheroniMarinacciRustichini:2006b,
   author        = {Maccheroni, Fabio and Marinacci, Massimo and Rustichini, Aldo},
-  date-added    = {2021-05-19 08:04:27 -0500},
-  date-modified = {2021-05-19 08:04:27 -0500},
   journal       = {Econometrica},
   keywords      = {*file-import-17-01-11},
   number        = {6},
-  pages         = {1147--1498},
+  pages         = {1447--1498},
   title         = {{Ambiguity Aversion, Robustness, and the Variational Representation of Preferences}},
   volume        = {74},
   year          = {2006}
@@ -392,8 +1245,6 @@ Note: Extended Information (like abstracts, doi, url's etc.) can be found in qua
 
   @article{GilboaSchmeidler:1989,
   author          = {Gilboa, Itzhak and Schmeidler, David},
-  date-added      = {2020-08-10 09:11:02 -0500},
-  date-modified   = {2020-08-10 09:11:02 -0500},
   journal         = {Journal of Mathematical Economics},
   keywords        = {climate,modeling},
   mendeley-groups = {nsfbib},
@@ -404,7 +1255,6 @@ Note: Extended Information (like abstracts, doi, url's etc.) can be found in qua
   volume          = {18},
   year            = {1989}
 }
-
 
 @book{Sutton_2018,
   title={Reinforcement learning: An introduction},
@@ -428,7 +1278,6 @@ Note: Extended Information (like abstracts, doi, url's etc.) can be found in qua
   url      = {https://ideas.repec.org/a/tpr/jeurec/v1y2003i1p68-123.html}
 }
 
-
 @article{BHS_2009,
   author   = {Barillas, Francisco and Hansen, Lars Peter and Sargent, Thomas J.},
   title    = {{Doubts or variability?}},
@@ -444,10 +1293,8 @@ Note: Extended Information (like abstracts, doi, url's etc.) can be found in qua
   url      = {https://ideas.repec.org/a/eee/jetheo/v144y2009i6p2388-2418.html}
 }
 
-
-
 @article{HST_1999,
-  author   = {Lars Peter Hansen and Thomas J. Sargent and Thomas D. Tallarini},
+  author   = {Hansen, Lars Peter and Sargent, Thomas J. and Tallarini, Thomas D.},
   title    = {{Robust Permanent Income and Pricing}},
   journal  = {Review of Economic Studies},
   year     = 1999,
@@ -461,6 +1308,23 @@ Note: Extended Information (like abstracts, doi, url's etc.) can be found in qua
   url      = {https://ideas.repec.org/a/oup/restud/v66y1999i4p873-907..html}
 }
 
+@article{simon1956dynamic,
+  title={Dynamic programming under uncertainty with a quadratic criterion function},
+  author={Simon, Herbert A},
+  journal={Econometrica, Journal of the Econometric Society},
+  pages={74--81},
+  year={1956},
+  publisher={JSTOR}
+}
+
+@article{theil1957note,
+  title={A note on certainty equivalence in dynamic planning},
+  author={Theil, Henri},
+  journal={Econometrica: Journal of the Econometric Society},
+  pages={346--349},
+  year={1957},
+  publisher={JSTOR}
+}
 
 @article{Jacobson_73,
   author  = {D. H. Jacobson},
@@ -472,9 +1336,6 @@ Note: Extended Information (like abstracts, doi, url's etc.) can be found in qua
   pages   = {124-131}
 }
 
-
-
-
  @book{Bucklew_2004,
   title     = {An Introduction  to Rare Event Simulation},
   author    = {James A. Bucklew},
@@ -483,8 +1344,6 @@ Note: Extended Information (like abstracts, doi, url's etc.) can be found in qua
   year      = {2004}
 }
 
-
-
  @book{Whittle_1990,
   author    = {Peter Whittle},
   title     = {Risk-Sensitive Optimal Control},
@@ -492,7 +1351,6 @@ Note: Extended Information (like abstracts, doi, url's etc.) can be found in qua
   publisher = {Wiley},
   address   = {New York}
 }
-
 
  @article{Whittle_1981,
   author  = {Peter Whittle},
@@ -521,8 +1379,8 @@ Note: Extended Information (like abstracts, doi, url's etc.) can be found in qua
 }
 
 @book{DMD_book,
-  title     = {Dynamic mode decomposition: data-driven modeling of complex systems},
-  author    = {J. N.  Kutz and  S. L. Brunton and  B. W, Brunton and  J. L. Proctor},
+  title     = {Dynamic Mode Decomposition: Data-Driven Modeling of Complex Systems},
+  author    = {Kutz, J. Nathan and Brunton, Steven L. and Brunton, Bingni W. and Proctor, Joshua L.},
   year      = {2016},
   publisher = {SIAM}
 }
@@ -535,28 +1393,24 @@ Note: Extended Information (like abstracts, doi, url's etc.) can be found in qua
   address   = {New York}
 }
 
-
 @book{bertsimas_tsitsiklis1997,
-  author    = {Bertsimas, D. & Tsitsiklis, J. N.},
-  title     = {{Introduction to linear optimization}},
+  author    = {Bertsimas, Dimitris and Tsitsiklis, John N.},
+  title     = {{Introduction to Linear Optimization}},
   publisher = {Athena Scientific},
   year      = {1997}
 }
 
 @book{hu_guo2018,
-  author    = {Hu, Y. & Guo, Y.},
+  author    = {Hu, Yunquan and Guo, Yaohuang},
   title     = {{Operations research}},
   publisher = {Tsinghua University Press},
   edition   = {5th},
   year      = {2018}
 }
 
-
 @article{definetti,
   author        = {Bruno de Finetti},
-  date-added    = {2014-12-26 17:45:57 +0000},
-  date-modified = {2014-12-26 17:45:57 +0000},
-  journal       = {Annales de l'Institute Henri Poincare'},
+  journal       = {Annales de l'Institut Henri Poincaré},
   note          = {English translation in Kyburg and Smokler (eds.), {\it Studies in Subjective Probability}, Wiley, New York, 1964},
   pages         = {1 - 68},
   title         = {La Prevision: Ses Lois Logiques, Ses Sources Subjectives},
@@ -803,11 +1657,12 @@ Note: Extended Information (like abstracts, doi, url's etc.) can be found in qua
   year    = {2018}
 }
 
-@article{pareto1896cours,
+@book{pareto1896cours,
   title   = {Cours d'{\'e}conomie politique},
-  author  = {Vilfredo, Pareto},
-  journal = {Rouge, Lausanne},
-  volume  = {2},
+  author  = {Pareto, Vilfredo},
+  publisher = {F. Rouge},
+  address = {Lausanne},
+  volume  = {1},
   year    = {1896}
 }
 
@@ -946,14 +1801,6 @@ Note: Extended Information (like abstracts, doi, url's etc.) can be found in qua
   publisher = {The University of Chicago Press}
 }
 
-@book{HS2013,
-  title     = {Recursive Linear Models of Dynamic Economics},
-  author    = {Hansen, Lars Peter and Thomas J. Sargent},
-  year      = {2013},
-  publisher = {Princeton University Press},
-  address   = {Princeton, New Jersey}
-}
-
 @article{Reffett1996,
   title     = {Production-based asset pricing in monetary economies with transactions costs},
   author    = {Reffett, Kevin L},
@@ -967,7 +1814,7 @@ Note: Extended Information (like abstracts, doi, url's etc.) can be found in qua
   title   = {Interactions Between the Multiplier Analysis
              and the Principle of Acceleration},
   author  = {Samuelson, Paul A.},
-  journal = {Review of Economic Studies},
+  journal = {The Review of Economics and Statistics},
   volume  = {21},
   number  = {2},
   year    = {1939},
@@ -1002,7 +1849,7 @@ Note: Extended Information (like abstracts, doi, url's etc.) can be found in qua
   title      = {On the Concept of Optimal Economic Growth},
   booktitle  = {The Economic Approach to Development Planning},
   address    = { Chicago},
-  publilsher = {Rand McNally},
+  publisher  = {Rand McNally},
   pages      = {225-287}
 }
 
@@ -1094,29 +1941,33 @@ Note: Extended Information (like abstracts, doi, url's etc.) can be found in qua
   publisher = {The University of Chicago Press}
 }
 
-@article{Deneckere1992,
-  title     = {Cyclical and chaotic behavior in a dynamic equilibrium model, with implications for fiscal policy},
-  author    = {Deneckere, Raymond J and Judd, Kenneth L},
-  journal   = {Cycles and chaos in economic equilibrium},
+@incollection{Deneckere1992,
+  title     = {Cyclical and Chaotic Behavior in a Dynamic Equilibrium Model, with Implications for Fiscal Policy},
+  author    = {Deneckere, Raymond J. and Judd, Kenneth L.},
+  editor    = {Benhabib, Jess},
+  booktitle = {Cycles and Chaos in Economic Equilibrium},
   pages     = {308--329},
   year      = {1992},
-  publisher = {Princeton University Press}
+  publisher = {Princeton University Press},
+  address   = {Princeton}
 }
 
 @article{Judd1985,
   title     = {On the performance of patents},
   author    = {Judd, Kenneth L},
   journal   = {Econometrica},
+  volume    = {53},
+  number    = {3},
   pages     = {567--585},
-  year      = {1985},
-  publisher = {JSTOR}
+  year      = {1985}
 }
 
 @book{Helpman1985,
-  title     = {Market structure and international trade},
-  author    = {Helpman, Elhanan and Krugman, Paul},
-  year      = {1985},
-  publisher = {MIT Press Cambridge}
+  title     = {Market Structure and Foreign Trade: Increasing Returns, Imperfect Competition, and the International Economy},
+  author    = {Helpman, Elhanan and Krugman, Paul R.},
+  year      = {1987},
+  publisher = {MIT Press},
+  address   = {Cambridge, MA}
 }
 
 @article{LettLud2004,
@@ -1142,13 +1993,13 @@ Note: Extended Information (like abstracts, doi, url's etc.) can be found in qua
 }
 
 @article{CampbellShiller88,
-  author  = {John Y. Campbell, Robert J. Shiller},
+  author  = {Campbell, John Y. and Shiller, Robert J.},
   title   = {{The Dividend-Price Ratio and Expectations of Future Dividends and Discount Factors}},
   journal = {Review of Financial Studies},
   year    = 1988,
   volume  = {1},
   number  = {3},
-  pages   = {195-228}
+  pages   = {195--228}
 }
 
 @book{Friedman98,
@@ -1173,16 +2024,6 @@ Note: Extended Information (like abstracts, doi, url's etc.) can be found in qua
   url      = {https://ideas.repec.org/a/ecm/emetrp/v71y2003i4p1239-1254.html}
 }
 
-@book{kreps,
-  author        = {David M. Kreps},
-  date-added    = {2014-12-26 17:45:57 +0000},
-  date-modified = {2014-12-26 17:45:57 +0000},
-  publisher     = {Westview Press},
-  series        = {Underground Classics in Economics},
-  title         = {Notes on the Theory of Choice},
-  year          = {1988}
-}
-
 @book{Kreps88,
   title     = {Notes on the Theory of Choice},
   author    = {David M. Kreps},
@@ -1192,9 +2033,9 @@ Note: Extended Information (like abstracts, doi, url's etc.) can be found in qua
 }
 
 @book{Bertsekas75,
-  author    = {Dmitri Bertsekas},
+  author    = {Bertsekas, Dimitri P.},
   title     = {Dynamic Programming and Stochastic Control},
-  year      = {1975},
+  year      = {1976},
   publisher = {Academic Press},
   address   = {New York}
 }
@@ -1217,6 +2058,27 @@ Note: Extended Information (like abstracts, doi, url's etc.) can be found in qua
   address   = {Amsterdam},
   pages     = {27-102}
 }
+@article{jacobson1973optimal,
+  title={Optimal stochastic linear systems with exponential performance criteria and their relation to deterministic differential games},
+  author={Jacobson, David},
+  journal={IEEE Transactions on Automatic control},
+  volume={18},
+  number={2},
+  pages={124--131},
+  year={1973},
+  publisher={IEEE}
+}
+
+@article{hansen1995discounted,
+  title={Discounted linear exponential quadratic gaussian control},
+  author={Hansen, Lars Peter and Sargent, Thomas J},
+  journal={IEEE Transactions on Automatic control},
+  volume={40},
+  number={5},
+  pages={968--971},
+  year={1995},
+  publisher={IEEE}
+}
 
 @article{Tall2000,
   author  = {Tallarini, Thomas D},
@@ -1229,41 +2091,34 @@ Note: Extended Information (like abstracts, doi, url's etc.) can be found in qua
   month   = {June}
 }
 
+@article{Hansen_Jagannathan_1991,
+  author  = {Hansen, Lars Peter and Jagannathan, Ravi},
+  title   = {Implications of Security Market Data for Models of Dynamic Economies},
+  journal = {Journal of Political Economy},
+  year    = {1991},
+  volume  = {99},
+  number  = {2},
+  pages   = {225--262},
+  doi     = {10.1086/261750}
+}
+
+@article{Weil_1989,
+  author  = {Weil, Philippe},
+  title   = {The Equity Premium Puzzle and the Risk-Free Rate Puzzle},
+  journal = {Journal of Monetary Economics},
+  year    = {1989},
+  volume  = {24},
+  number  = {3},
+  pages   = {401--421},
+  doi     = {10.1016/0304-3932(89)90028-7}
+}
+
 @book{Lucas1987,
   title     = {Models of business cycles},
   author    = {Lucas, Robert E},
   volume    = {26},
   year      = {1987},
   publisher = {Oxford Blackwell}
-}
-
-@article{hansen2009long,
-  title     = {Long-term risk: An operator approach},
-  author    = {Hansen, Lars Peter and Scheinkman, Jos{\'e} A},
-  journal   = {Econometrica},
-  volume    = {77},
-  number    = {1},
-  pages     = {177--234},
-  year      = {2009},
-  publisher = {Wiley Online Library}
-}
-
-@article{Hans_Scheink_2009,
-  author  = {Lars Peter Hansen and Jose A. Scheinkman},
-  title   = {Long-Term Risk: An Operator Approach},
-  journal = {Econometrica},
-  year    = {2009},
-  volume  = {77},
-  number  = {1},
-  pages   = {177-234},
-  month   = {01}
-}
-
-@book{hansen2008robustness,
-  title     = {Robustness},
-  author    = {Hansen, Lars Peter and Sargent, Thomas J},
-  year      = {2008},
-  publisher = {Princeton university press}
 }
 
 @book{Whittle1963,
@@ -1291,9 +2146,9 @@ Note: Extended Information (like abstracts, doi, url's etc.) can be found in qua
 }
 
 @book{Athanasios1991,
-  title     = {Probability, random variables, and stochastic processes},
-  author    = {Athanasios, Papoulis and Pillai, S Unnikrishna},
-  publisher = {Mc-Graw Hill},
+  title     = {Probability, Random Variables, and Stochastic Processes},
+  author    = {Papoulis, Athanasios},
+  publisher = {McGraw-Hill},
   year      = {1991}
 }
 
@@ -1323,7 +2178,7 @@ Note: Extended Information (like abstracts, doi, url's etc.) can be found in qua
   year    = 2001,
   volume  = {69},
   number  = {6},
-  pages   = {1491-1518},
+  pages   = {1491--1518},
   month   = {November}
 }
 
@@ -1376,6 +2231,16 @@ Note: Extended Information (like abstracts, doi, url's etc.) can be found in qua
   volume  = {92},
   number  = {2},
   pages   = {323-336}
+}
+
+@article{Morris1996,
+  author  = {Stephen Morris},
+  title   = {Speculative Investor Behavior and Learning},
+  journal = {The Quarterly Journal of Economics},
+  year    = {1996},
+  volume  = {111},
+  number  = {4},
+  pages   = {1111-1133}
 }
 
 @article{pal2013,
@@ -1458,9 +2323,12 @@ Note: Extended Information (like abstracts, doi, url's etc.) can be found in qua
 }
 
 @article{davis2006flow,
-  title   = {The flow approach to labor markets: New data sources, micro-macro links and the recent downturn},
-  author  = {Davis, Steven J and Faberman, R Jason and Haltiwanger, John},
+  title   = {The Flow Approach to Labor Markets: New Data Sources and Micro-Macro Links},
+  author  = {Davis, Steven J. and Faberman, R. Jason and Haltiwanger, John},
   journal = {Journal of Economic Perspectives},
+  volume  = {20},
+  number  = {3},
+  pages   = {3--26},
   year    = {2006}
 }
 
@@ -1485,17 +2353,6 @@ Note: Extended Information (like abstracts, doi, url's etc.) can be found in qua
   month   = {December}
 }
 
-@article{aiyagari2002optimal,
-  title     = {Optimal taxation without state-contingent debt},
-  author    = {Aiyagari, S Rao and Marcet, Albert and Sargent, Thomas J and Sepp{\"a}l{\"a}, Juha},
-  journal   = {Journal of Political Economy},
-  volume    = {110},
-  number    = {6},
-  pages     = {1220--1254},
-  year      = {2002},
-  publisher = {The University of Chicago Press}
-}
-
 @article{Rust1996,
   title   = {Numerical dynamic programming in economics},
   author  = {Rust, John},
@@ -1506,11 +2363,9 @@ Note: Extended Information (like abstracts, doi, url's etc.) can be found in qua
 }
 
 @book{AKR1990,
-  author    = {Amman, H. M. and Kendrick, D.A. and Rust, J.},
-  address   = {Burlington, MA},
-  publisher = {Elsevier},
+  editor    = {Amman, H. M. and Kendrick, D. A. and Rust, John},
   title     = {{Handbook of Computational Economics}},
-  year      = {1990}
+  year      = {1996}
 }
 
 @book{AndersonMoore2005,
@@ -1704,10 +2559,12 @@ Note: Extended Information (like abstracts, doi, url's etc.) can be found in qua
 }
 
 @article{HallMishkin1982,
-  author  = {Hall, Robert E and Mishkin, Frederic S},
-  journal = {National Bureau of Economic Research Working Paper Series},
+  author  = {Hall, Robert E. and Mishkin, Frederic S.},
+  journal = {Econometrica},
   title   = {{The Sensitivity of Consumption to Transitory Income: Estimates from Panel Data on Households}},
-  volume  = {No. 505},
+  volume  = {50},
+  number  = {2},
+  pages   = {461--481},
   year    = {1982}
 }
 
@@ -1780,6 +2637,34 @@ Note: Extended Information (like abstracts, doi, url's etc.) can be found in qua
   pages     = {1127--1150},
   year      = {1992},
   publisher = {JSTOR}
+}
+
+@book{bacsar2008h,
+  title={H-infinity optimal control and related minimax design problems: a dynamic game approach},
+  author={Ba{\c{s}}ar, Tamer and Bernhard, Pierre},
+  year={2008},
+  publisher={Springer Science \& Business Media}
+}
+
+@article{sargent1981interpreting,
+  title={Interpreting economic time series},
+  author={Sargent, Thomas J},
+  journal={Journal of political Economy},
+  volume={89},
+  number={2},
+  pages={213--248},
+  year={1981},
+  publisher={The University of Chicago Press}
+}
+
+@inproceedings{lucas1976econometric,
+  title={Econometric policy evaluation: A critique},
+  author={Lucas, Robert E Jr},
+  booktitle={Carnegie-Rochester conference series on public policy},
+  volume={1},
+  pages={19--46},
+  year={1976},
+  organization={North-Holland}
 }
 
 @article{HopenhaynRogerson1993,
@@ -1857,23 +2742,23 @@ Note: Extended Information (like abstracts, doi, url's etc.) can be found in qua
 }
 
 @article{KydlandPrescott1977,
-  author  = {Kydland, Finn E., and Edward C. Prescott},
+  author  = {Kydland, Finn E. and Prescott, Edward C.},
   journal = {Journal of Political Economy},
-  pages   = {867-896},
+  pages   = {473--492},
   title   = {Rules Rather than Discretion: The Inconsistency of Optimal Plans},
-  volume  = {106},
-  number  = {5},
+  volume  = {85},
+  number  = {3},
   year    = {1977}
 }
 
 @article{KydlandPrescott1980,
-  author  = {Kydland, Finn E., and Edward C. Prescott},
-  journal = {Econometrics},
-  pages   = {1345-2370},
+  author  = {Kydland, Finn E. and Prescott, Edward C.},
+  journal = {Econometrica},
+  pages   = {1345--1370},
   title   = {Time to Build and Aggregate Fluctuations},
   volume  = {50},
   number  = {6},
-  year    = {1980}
+  year    = {1982}
 }
 
 @book{LasotaMackey1994,
@@ -1894,7 +2779,7 @@ Note: Extended Information (like abstracts, doi, url's etc.) can be found in qua
 
 @article{Lucas1978,
   author  = {Lucas, Jr., Robert E},
-  journal = {Econometrica: Journal of the Econometric Society},
+  journal = {Econometrica},
   number  = {6},
   pages   = {1429--1445},
   title   = {{Asset prices in an exchange economy}},
@@ -1902,18 +2787,10 @@ Note: Extended Information (like abstracts, doi, url's etc.) can be found in qua
   year    = {1978}
 }
 
-@article{LucasPrescott1971,
-  author  = {Lucas, Jr., Robert E and Prescott, Edward C},
-  journal = {Econometrica: Journal of the Econometric Society},
-  pages   = {659--681},
-  title   = {{Investment under uncertainty}},
-  year    = {1971}
-}
-
 @article{LucasStokey1983,
-  author  = {Lucas, Jr., Robert E and Stokey, Nancy L},
-  journal = {Journal of monetary Economics},
-  number  = {3},
+  author  = {Lucas, Jr., Robert E. and Stokey, Nancy L.},
+  journal = {Journal of Monetary Economics},
+  number  = {1},
   pages   = {55--93},
   title   = {{Optimal Fiscal and Monetary Policy in an Economy without Capital}},
   volume  = {12},
@@ -1921,13 +2798,60 @@ Note: Extended Information (like abstracts, doi, url's etc.) can be found in qua
 }
 
 @article{MarcetMarimon1994,
-  author      = {Albert Marcet and Ramon Marimon},
-  title       = {{Recursive contracts}},
-  year        = 1994,
-  institution = {Department of Economics and Business, Universitat Pompeu Fabra},
-  type        = {Economics Working Papers},
-  url         = {http://ideas.repec.org/p/upf/upfgen/337.html},
-  number      = {337}
+  author  = {Marcet, Albert and Marimon, Ramon},
+  title   = {{Recursive Contracts}},
+  journal = {Econometrica},
+  volume  = {87},
+  number  = {5},
+  pages   = {1589--1631},
+  year    = {2019}
+}
+
+@article{MarcetSargent1989jet,
+  author    = {Marcet, Albert and Sargent, Thomas J.},
+  title     = {Convergence of Least Squares Learning Mechanisms in
+               Self-Referential Linear Stochastic Models},
+  journal   = {Journal of Economic Theory},
+  year      = {1989},
+  volume    = {48},
+  number    = {2},
+  pages     = {337--368},
+  publisher = {Elsevier},
+  doi       = {10.1016/0022-0531(89)90032-X}
+}
+
+@article{Ljung1977,
+  author  = {Ljung, Lennart},
+  title   = {Analysis of Recursive Stochastic Algorithms},
+  journal = {IEEE Transactions on Automatic Control},
+  year    = {1977},
+  volume  = {22},
+  number  = {4},
+  pages   = {551--575},
+  doi     = {10.1109/TAC.1977.1101561}
+}
+
+@article{Evans1985,
+  author  = {Evans, George W.},
+  title   = {Expectational Stability and the Multiple Equilibria Problem
+             in Linear Rational Expectations Models},
+  journal = {Quarterly Journal of Economics},
+  year    = {1985},
+  volume  = {100},
+  number  = {4},
+  pages   = {1217--1233},
+  doi     = {10.2307/1885681}
+}
+
+@article{FourgeaudGourieroux1986,
+  author  = {Fourgeaud, Claude and Gourieroux, Christian and Pradel, Jacqueline},
+  title   = {Learning Procedures and Convergence to Rationality},
+  journal = {Econometrica},
+  year    = {1986},
+  volume  = {54},
+  number  = {4},
+  pages   = {845--868},
+  doi     = {10.2307/1912839}
 }
 
 @article{MarcetSargent1989,
@@ -2043,12 +2967,13 @@ Note: Extended Information (like abstracts, doi, url's etc.) can be found in qua
 }
 
 @article{PearlmanCurrieLevine1986,
-  author  = {Pearlman, J.G. and Currie, D.A. and Levine, P.L.},
-  title   = {Rational expectations with partial information},
-  journal = {Economic Modeling},
+  author  = {Pearlman, Joseph and Currie, David and Levine, Paul},
+  title   = {Rational expectations models with partial information},
+  journal = {Economic Modelling},
   volume  = {3},
-  pages   = {90-105},
-  year    = {1992}
+  number  = {2},
+  pages   = {90--105},
+  year    = {1986}
 }
 
 @book{Popper1992,
@@ -2063,9 +2988,9 @@ Note: Extended Information (like abstracts, doi, url's etc.) can be found in qua
   author  = {Prescott, Edward C.},
   year    = {1977},
   title   = {Should Control Theory Be Used for Economic Stabilization?},
-  journal = {Journal of Monetary Economics},
+  journal = {Carnegie-Rochester Conference Series on Public Policy},
   volume  = {7},
-  pages   = {13-38}
+  pages   = {13--38}
 }
 
 @article{Rabault2002,
@@ -2101,12 +3026,13 @@ Note: Extended Information (like abstracts, doi, url's etc.) can be found in qua
 }
 
 @article{Sargent1979,
-  author  = {Sargent, T J},
+  author  = {Sargent, Thomas J.},
   year    = {1979},
   title   = {A Note On Maximum Likelihood Estimation of The Rational Expectations Model of The Term Structure},
   journal = {Journal of Monetary Economics},
-  volume  = {35},
-  pages   = {245-274}
+  volume  = {5},
+  number  = {1},
+  pages   = {133--143}
 }
 
 @book{Sargent1987,
@@ -2116,6 +3042,16 @@ Note: Extended Information (like abstracts, doi, url's etc.) can be found in qua
   address   = {New York},
   title     = {Macroeconomic Theory},
   year      = {1987}
+}
+
+@article{Sargent1989,
+  author  = {Sargent, Thomas J},
+  title   = {Two Models of Measurements and the Investment Accelerator},
+  journal = {Journal of Political Economy},
+  volume  = {97},
+  number  = {2},
+  pages   = {251--287},
+  year    = {1989}
 }
 
 @article{SchechtmanEscudero1977,
@@ -2139,66 +3075,27 @@ Note: Extended Information (like abstracts, doi, url's etc.) can be found in qua
   year      = {1969}
 }
 
-@article{bansal2004risks,
-  title     = {Risks for the long run: A potential resolution of asset pricing puzzles},
-  author    = {Bansal, Ravi and Yaron, Amir},
-  journal   = {The journal of Finance},
-  volume    = {59},
-  number    = {4},
-  pages     = {1481--1509},
-  year      = {2004},
-  publisher = {Wiley Online Library}
-}
-
 @article{Bansal_Yaron_2004,
-  author   = {Ravi Bansal and Amir Yaron},
-  title    = {{Risks for the Long Run: A Potential Resolution of Asset Pricing Puzzles}},
-  journal  = {Journal of Finance},
-  year     = 2004,
-  volume   = {59},
-  number   = {4},
-  pages    = {1481-1509},
-  month    = {08},
-  keywords = {},
-  doi      = {},
-  abstract = { We model consumption and dividend growth rates as containing (1) a small long-run predictable component, and (2) fluctuating economic uncertainty (consumption volatility). These dynamics, for which we provide empirical support, in conjunction with Epstein and Zin's (1989) preferences, can explain key asset markets phenomena. In our economy, financial markets dislike economic uncertainty and better long-run growth prospects raise equity prices. The model can justify the equity premium, the risk-free rate, and the volatility of the market return, risk-free rate, and the price-dividend ratio. As in the data, dividend yields predict returns and the volatility of returns is time-varying. Copyright 2004 by The American Finance Association.},
-  url      = {https://ideas.repec.org/a/bla/jfinan/v59y2004i4p1481-1509.html}
+  author  = {Bansal, Ravi and Yaron, Amir},
+  title   = {Risks for the Long Run: A Potential Resolution of Asset Pricing Puzzles},
+  journal = {Journal of Finance},
+  year    = {2004},
+  volume  = {59},
+  number  = {4},
+  pages   = {1481--1509},
+  doi     = {10.1111/j.1540-6261.2004.00670.x}
 }
 
 @article{hansen2008consumption,
-  title     = {Consumption strikes back? Measuring long-run risk},
-  author    = {Hansen, Lars Peter and Heaton, John C and Li, Nan},
-  journal   = {Journal of Political economy},
+  title     = {Consumption Strikes Back? Measuring Long-Run Risk},
+  author    = {Hansen, Lars Peter and Heaton, John C. and Li, Nan},
+  journal   = {Journal of Political Economy},
   volume    = {116},
   number    = {2},
   pages     = {260--302},
   year      = {2008},
-  publisher = {The University of Chicago Press}
-}
-
-@article{HHL_2008,
-  author   = {Lars Peter Hansen and John C. Heaton and Nan Li},
-  title    = {{Consumption Strikes Back? Measuring Long-Run Risk}},
-  journal  = {Journal of Political Economy},
-  year     = 2008,
-  volume   = {116},
-  number   = {2},
-  pages    = {260-302},
-  month    = {04},
-  keywords = {},
-  doi      = {},
-  abstract = { We characterize and measure a long-term risk-return trade-off for the valuation of cash flows exposed to fluctuations in macroeconomic growth. This trade-off features risk prices of cash flows that are realized far into the future but continue to be reflected in asset values. We apply this analysis to claims on aggregate cash flows and to cash flows from value and growth portfolios by imputing values to the long-run dynamic responses of cash flows to macroeconomic shocks. We explore the sensitivity of our results to features of the economic valuation model and of the model cash flow dynamics. (c) 2008 by The University of Chicago. All rights reserved.},
-  url      = {https://ideas.repec.org/a/ucp/jpolec/v116y2008i2p260-302.html}
-}
-
-@article{hansen2007beliefs,
-  title   = {Beliefs, doubts and learning: Valuing macroeconomic risk},
-  author  = {Hansen, Lars Peter},
-  journal = {American Economic Review},
-  volume  = {97},
-  number  = {2},
-  pages   = {1--30},
-  year    = {2007}
+  publisher = {The University of Chicago Press},
+  doi       = {10.1086/588200}
 }
 
 @article{Hansen_2007,
@@ -2214,16 +3111,6 @@ Note: Extended Information (like abstracts, doi, url's etc.) can be found in qua
   doi      = {},
   abstract = {No abstract is available for this item.},
   url      = {https://ideas.repec.org/a/aea/aecrev/v97y2007i2p1-30.html}
-}
-
-@article{lucas2003macroeconomic,
-  title   = {Macroeconomic priorities},
-  author  = {Lucas Jr, Robert E},
-  journal = {American economic review},
-  volume  = {93},
-  number  = {1},
-  pages   = {1--14},
-  year    = {2003}
 }
 
 @article{Lucas_2003,
@@ -2289,7 +3176,123 @@ Note: Extended Information (like abstracts, doi, url's etc.) can be found in qua
   title   = {Forecasting the Forecasts of Others},
   journal = {Journal of Political Economy},
   volume  = {91},
-  pages   = {546-588}
+  number  = {4},
+  pages   = {546--588},
+  doi     = {10.1086/261166}
+}
+
+@article{tobin1992old,
+  title={An old Keynesian counterattacks},
+  author={Tobin, James},
+  journal={Eastern Economic Journal},
+  volume={18},
+  number={4},
+  pages={387--400},
+  year={1992},
+  publisher={JSTOR}
+}
+
+@article{hicks1937mr,
+  title={Mr. Keynes and the" classics"; a suggested interpretation},
+  author={Hicks, John R},
+  journal={Econometrica},
+  pages={147--159},
+  year={1937}
+}
+
+@article{GrossmanShiller1981,
+  title={The determinants of the variability of stock market prices},
+  author={Grossman, Sanford J and Shiller, Robert J},
+  journal={American Economic Review},
+  volume={71},
+  number={2},
+  pages={222--227},
+  year={1981}
+}
+
+@article{hansen1983stochastic,
+  title={Stochastic consumption, risk aversion, and the temporal behavior of asset returns},
+  author={Hansen, Lars Peter and Singleton, Kenneth J},
+  journal={Journal of political economy},
+  volume={91},
+  number={2},
+  pages={249--265},
+  year={1983},
+  publisher={The University of Chicago Press}
+}
+
+@article{hansen1982generalized,
+  title={Generalized instrumental variables estimation of nonlinear rational expectations models},
+  author={Hansen, Lars Peter and Singleton, Kenneth J},
+  journal={Econometrica: Journal of the Econometric Society},
+  pages={1269--1286},
+  year={1982},
+  publisher={JSTOR}
+}
+
+@article{abel1990asset,
+  title={Asset prices under habit formation and catching up with the Joneses},
+  author={Abel, Andrew B},
+  journal={American Economic Review},
+  volume={80},
+  number={2},
+  pages={38--42},
+  year={1990}
+}
+
+@article{campbell1999force,
+  title={By force of habit: A consumption-based explanation of aggregate stock market behavior},
+  author={Campbell, John Y and Cochrane, John H},
+  journal={Journal of Political Economy},
+  volume={107},
+  number={2},
+  pages={205--251},
+  year={1999},
+  publisher={The University of Chicago Press}
+}
+
+@article{barro2006rare,
+  title={Rare disasters and asset markets in the twentieth century},
+  author={Barro, Robert J},
+  journal={The Quarterly Journal of Economics},
+  volume={121},
+  number={3},
+  pages={823--866},
+  year={2006},
+  publisher={MIT Press}
+}
+
+@incollection{Brock1982,
+  title={Asset prices in a production economy},
+  author={Brock, William A},
+  booktitle={The Economics of Information and Uncertainty},
+  editor={McCall, John J.},
+  pages={1--46},
+  year={1982},
+  publisher={University of Chicago Press},
+  address={Chicago}
+}
+
+@article{PrescottMehra1980,
+  title={Recursive competitive equilibrium: The case of homogeneous households},
+  author={Prescott, Edward C and Mehra, Rajnish},
+  journal={Econometrica},
+  volume={48},
+  number={6},
+  pages={1365--1379},
+  year={1980},
+  publisher={JSTOR}
+}
+
+@article{Hansen1982,
+  title={Large sample properties of generalized method of moments estimators},
+  author={Hansen, Lars Peter},
+  journal={Econometrica},
+  volume={50},
+  number={4},
+  pages={1029--1054},
+  year={1982},
+  publisher={JSTOR}
 }
 
 @incollection{Uhlig2001,
@@ -2359,26 +3362,6 @@ Note: Extended Information (like abstracts, doi, url's etc.) can be found in qua
   author      = {Giannoni, Marc P and Woodford, Michael},
   year        = {2010},
   institution = {National Bureau of Economic Research}
-}
-
-@article{miller1985dynamic,
-  title     = {Dynamic games and the time inconsistency of optimal policy in open economies},
-  author    = {Miller, Marcus and Salmon, Mark},
-  journal   = {The Economic Journal},
-  pages     = {124--137},
-  year      = {1985},
-  publisher = {JSTOR}
-}
-
-@article{pearlman1986rational,
-  title     = {Rational expectations models with partial information},
-  author    = {Pearlman, Joseph and Currie, David and Levine, Paul},
-  journal   = {Economic Modelling},
-  volume    = {3},
-  number    = {2},
-  pages     = {90--105},
-  year      = {1986},
-  publisher = {Elsevier}
 }
 
 @techreport{backus1986consistency,
@@ -2480,17 +3463,6 @@ Note: Extended Information (like abstracts, doi, url's etc.) can be found in qua
   publisher = {Wiley Online Library}
 }
 
-@article{coase1937nature,
-  title     = {The nature of the firm},
-  author    = {Coase, Ronald Harry},
-  journal   = {economica},
-  volume    = {4},
-  number    = {16},
-  pages     = {386--405},
-  year      = {1937},
-  publisher = {Wiley Online Library}
-}
-
 @article{do1999solutions,
   title     = {Solutions for the linear-quadratic control problem of Markov jump linear systems},
   author    = {Do Val, JBR and Geromel, JC and Costa, OLV},
@@ -2573,12 +3545,14 @@ Note: Extended Information (like abstracts, doi, url's etc.) can be found in qua
 }
 
 @article{Neyman_Pearson,
-  author  = {Neyman, J. and  Pearson, E. S},
+  author  = {Neyman, J. and Pearson, E. S.},
   year    = {1933},
   title   = {On the problem of the most efficient tests of statistical
              hypotheses},
-  journal = {Phil. Trans. R. Soc. Lond. A. 231 (694–706)},
-  pages   = {289–337}
+  journal = {Philosophical Transactions of the Royal Society of London},
+  volume  = {231},
+  number  = {694--706},
+  pages   = {289--337}
 }
 
 @article{ma2020income,
@@ -2620,6 +3594,37 @@ Note: Extended Information (like abstracts, doi, url's etc.) can be found in qua
   publisher = {JSTOR}
 }
 
+@article{huang1997two,
+  title   = {Two computations to fund social security},
+  author  = {Huang, He and Imrohoroglu, Selahattin and Sargent, Thomas J},
+  journal = {Macroeconomic Dynamics},
+  volume  = {1},
+  number  = {1},
+  pages   = {7--44},
+  year    = {1997},
+  publisher = {Cambridge University Press}
+}
+
+@techreport{faber1982life,
+  title   = {Life Tables for the {United States}: 1900--2050},
+  author  = {Faber, Joseph F},
+  year    = {1982},
+  number  = {Actuarial Study No. 87},
+  institution = {Social Security Administration, Office of the Actuary},
+  type    = {Actuarial Study}
+}
+
+@article{hansen1993cyclical,
+  title   = {The Cyclical and Secular Behaviour of the Labour Input: Comparing Efficiency Units and Hours Worked},
+  author  = {Hansen, Gary D},
+  journal = {Journal of Applied Econometrics},
+  volume  = {8},
+  number  = {1},
+  pages   = {71--80},
+  year    = {1993},
+  publisher = {Wiley}
+}
+
 @book{auerbach1987dynamic,
   title   = {Dynamic fiscal policy},
   author  = {Auerbach, Alan J and Kotlikoff, Laurence J},
@@ -2646,27 +3651,6 @@ Note: Extended Information (like abstracts, doi, url's etc.) can be found in qua
   year={2024}
 }
 
-@article{Lucas_Prescott_1971,
-  author    = {Lucas, Robert E., Jr. and Prescott, Edward C.},
-  title     = {Investment under Uncertainty},
-  journal   = {Econometrica},
-  volume    = {39},
-  number    = {5},
-  pages     = {659--681},
-  year      = {1971}
-}
-
-
-@article{Blume_Easley2006,
-  author    = {Blume, Lawrence and Easley, David},
-  title     = {If You're So Smart, Why Aren't You Rich? {B}elief Selection in Complete and Incomplete Markets},
-  journal   = {Econometrica},
-  volume    = {74},
-  number    = {4},
-  pages     = {929--966},
-  year      = {2006}
-}
-
 @article{MaCurdy1982,
   title={The use of time series processes to model the error structure of earnings in a longitudinal data analysis},
   author={MaCurdy, Thomas E.},
@@ -2689,3 +3673,434 @@ Note: Extended Information (like abstracts, doi, url's etc.) can be found in qua
   publisher={Wiley Online Library}
 }
 
+@article{Chow1968,
+  title={The Acceleration Principle and the Nature of Business Cycles},
+  author={Chow, Gregory C.},
+  journal={The Quarterly Journal of Economics},
+  volume={82},
+  number={3},
+  pages={403--418},
+  year={1968},
+  month={aug},
+  publisher={Oxford University Press}
+}
+
+@article{ChowLevitan1969,
+  title={Nature of Business Cycles Implicit in a Linear Economic Model},
+  author={Chow, Gregory C. and Levitan, Richard E.},
+  journal={The Quarterly Journal of Economics},
+  volume={83},
+  number={3},
+  pages={504--517},
+  year={1969},
+  month={aug},
+  publisher={Oxford University Press}
+}
+
+@article{hansen2020twisted,
+  author   = {Hansen, Lars Peter and Sz\H{o}ke, Bal\'{a}zs and Han, Lloyd S. and Sargent, Thomas J.},
+  title    = {{Twisted probabilities, uncertainty, and prices}},
+  journal  = {Journal of Econometrics},
+  year     = 2020,
+  volume   = {216},
+  number   = {1},
+  pages    = {151--174}
+}
+
+@unpublished{piazzesi2015trend,
+  author = {Piazzesi, Monika and Salomao, Juliana and Schneider, Martin},
+  title  = {{Trend and Cycle in Bond Premia}},
+  year   = 2015,
+  note   = {Working Paper, Stanford University}
+}
+
+@article{szoke2022estimating,
+  author  = {Sz\H{o}ke, Bal\'{a}zs},
+  title   = {{Estimating robustness}},
+  journal = {Journal of Economic Theory},
+  year    = 2022,
+  volume  = {199},
+  pages   = {105225}
+}
+
+@article{AngPiazzesi2003,
+  author  = {Ang, Andrew and Piazzesi, Monika},
+  title   = {{A no-arbitrage vector autoregression of term structure dynamics with macroeconomic and latent variables}},
+  journal = {Journal of Monetary Economics},
+  year    = 2003,
+  volume  = {50},
+  number  = {4},
+  pages   = {745--787}
+}
+
+@article{csiszar1963,
+  author  = {Csisz{\'a}r, Imre},
+  title   = {{Eine informationstheoretische Ungleichung und ihre Anwendung auf den Beweis der Ergodizit{\"a}t von Markoffschen Ketten}},
+  journal = {Magyar Tud. Akad. Mat. Kutat{\'o} Int. K{\"o}zl.},
+  year    = 1963,
+  volume  = {8},
+  pages   = {85--108}
+}
+
+@article{morimoto1963,
+  author  = {Morimoto, Tetsuzo},
+  title   = {{Markov Processes and the H-Theorem}},
+  journal = {Journal of the Physical Society of Japan},
+  year    = 1963,
+  volume  = {18},
+  number  = {3},
+  pages   = {328--331},
+  doi     = {10.1143/JPSJ.18.328}
+}
+
+@article{ali1966,
+  author  = {Ali, S. M. and Silvey, S. D.},
+  title   = {{A general class of coefficients of divergence of one distribution from another}},
+  journal = {Journal of the Royal Statistical Society, Series B},
+  year    = 1966,
+  volume  = {28},
+  number  = {1},
+  pages   = {131--142}
+}
+
+@article{liese2012,
+  author  = {Liese, Friedrich},
+  title   = {{phi-divergences, sufficiency, Bayes sufficiency, and deficiency}},
+  journal = {Kybernetika},
+  year    = 2012,
+  volume  = {48},
+  number  = {4},
+  pages   = {690--713}
+}
+
+@book{chentsov1981,
+  author    = {{\v{C}}encov, Nikolai N.},
+  title     = {{Statistical Decision Rules and Optimal Inference}},
+  series    = {Translations of Mathematical Monographs},
+  volume    = {53},
+  publisher = {American Mathematical Society},
+  address   = {Providence, RI},
+  year      = 1981
+}
+
+@book{amari_nagaoka2000,
+  author    = {Amari, Shun-ichi and Nagaoka, Hiroshi},
+  title     = {{Methods of Information Geometry}},
+  series    = {Translations of Mathematical Monographs},
+  volume    = {191},
+  publisher = {American Mathematical Society and Oxford University Press},
+  address   = {Providence, RI},
+  year      = 2000
+}
+
+@inproceedings{tishby_pereira_bialek1999,
+  author    = {Tishby, Naftali and Pereira, Fernando C. and Bialek, William},
+  title     = {{The Information Bottleneck Method}},
+  booktitle = {Proceedings of the 37th Annual Allerton Conference on Communication, Control, and Computing},
+  year      = 1999,
+  pages     = {368--377}
+}
+
+@article{shwartz_ziv_tishby2017,
+  author  = {Shwartz-Ziv, Ravid and Tishby, Naftali},
+  title   = {{Opening the Black Box of Deep Neural Networks via Information}},
+  journal = {arXiv preprint arXiv:1703.00810},
+  year    = 2017
+}
+
+@article{kihlstrom_mirman1975,
+  author    = {Kihlstrom, Richard E. and Mirman, Leonard J.},
+  title     = {Information and Market Equilibrium},
+  journal   = {The Bell Journal of Economics},
+  volume    = {6},
+  number    = {1},
+  pages     = {357--376},
+  year      = {1975},
+  publisher = {The RAND Corporation}
+}
+
+@article{muth1961,
+  author  = {Muth, John F.},
+  title   = {Rational Expectations and the Theory of Price Movements},
+  journal = {Econometrica},
+  volume  = {29},
+  number  = {3},
+  pages   = {315--335},
+  year    = {1961}
+}
+
+@article{radner1972,
+  author  = {Radner, Roy},
+  title   = {Existence of Equilibrium of Plans, Prices, and Price Expectations in a Sequence of Markets},
+  journal = {Econometrica},
+  volume  = {40},
+  number  = {2},
+  pages   = {289--303},
+  year    = {1972}
+}
+
+@article{arrow1964,
+  author  = {Arrow, Kenneth J.},
+  title   = {The Role of Securities in the Optimal Allocation of Risk-bearing},
+  journal = {Review of Economic Studies},
+  volume  = {31},
+  number  = {2},
+  pages   = {91--96},
+  year    = {1964}
+}
+
+@article{grossman1976,
+  author  = {Grossman, Sanford J.},
+  title   = {On the Efficiency of Competitive Stock Markets Where Trades Have Diverse Information},
+  journal = {Journal of Finance},
+  volume  = {31},
+  number  = {2},
+  pages   = {573--585},
+  year    = {1976}
+}
+
+@incollection{BrayKreps1987,
+  author    = {Bray, Margaret M. and Kreps, David M.},
+  title     = {Rational Learning and Rational Expectations},
+  booktitle = {Arrow and the Ascent of Modern Economic Theory},
+  editor    = {Feiwel, George R.},
+  publisher = {Palgrave Macmillan},
+  address   = {London},
+  year      = {1987},
+  pages     = {597--625},
+  doi       = {10.1007/978-1-349-07239-2_19}
+}
+
+@article{Bray1982,
+  author  = {Bray, Margaret M.},
+  title   = {Learning, Estimation, and the Stability of Rational Expectations},
+  journal = {Journal of Economic Theory},
+  year    = {1982},
+  volume  = {26},
+  number  = {2},
+  pages   = {318--339},
+  doi     = {10.1016/0022-0531(82)90007-2}
+}
+
+@article{BraySavin1986,
+  author  = {Bray, Margaret M. and Savin, N. E.},
+  title   = {Rational Expectations Equilibria, Learning and Model Specification},
+  journal = {Econometrica},
+  year    = {1986},
+  volume  = {54},
+  number  = {5},
+  pages   = {1129--1160},
+  doi     = {10.2307/1912325}
+}
+
+@article{Radner1979,
+  author  = {Radner, Roy},
+  title   = {Rational Expectations Equilibrium: Generic Existence and the Information Revealed by Prices},
+  journal = {Econometrica},
+  year    = {1979},
+  volume  = {47},
+  number  = {3},
+  pages   = {655--678},
+  doi     = {10.2307/1910413}
+}
+
+@article{Jordan1982,
+  author  = {Jordan, James S.},
+  title   = {The Generic Existence of Rational Expectations Equilibrium in the Higher Dimensional Case},
+  journal = {Journal of Economic Theory},
+  year    = {1982},
+  volume  = {26},
+  number  = {2},
+  pages   = {224--243},
+  doi     = {10.1016/0022-0531(82)90002-3}
+}
+
+@article{Jordan1982b,
+  author  = {Jordan, James S.},
+  title   = {Admissible Market Data Structures: A Complete Characterization},
+  journal = {Journal of Economic Theory},
+  year    = {1982},
+  volume  = {28},
+  number  = {1},
+  pages   = {19--31},
+  doi     = {10.1016/0022-0531(82)90089-8}
+}
+
+@article{Admati1985,
+  author  = {Admati, Anat R.},
+  title   = {A Noisy Rational Expectations Equilibrium for Multi-Asset Securities Markets},
+  journal = {Econometrica},
+  year    = {1985},
+  volume  = {53},
+  number  = {3},
+  pages   = {629--657},
+  doi     = {10.2307/1911659}
+}
+
+@article{GrossmanStiglitz1980,
+  author  = {Grossman, Sanford J. and Stiglitz, Joseph E.},
+  title   = {On the Impossibility of Informationally Efficient Markets},
+  journal = {American Economic Review},
+  year    = {1980},
+  volume  = {70},
+  number  = {3},
+  pages   = {393--408}
+}
+
+@article{AndersonSonnenschein1982,
+  author  = {Anderson, Robert M. and Sonnenschein, Hugo},
+  title   = {On the Existence of Rational Expectations Equilibrium},
+  journal = {Journal of Economic Theory},
+  year    = {1982},
+  volume  = {26},
+  number  = {2},
+  pages   = {261--278},
+  doi     = {10.1016/0022-0531(82)90004-7}
+}
+
+@article{BlumeEasley1982,
+  author  = {Blume, Lawrence E. and Easley, David},
+  title   = {Learning to be Rational},
+  journal = {Journal of Economic Theory},
+  year    = {1982},
+  volume  = {26},
+  number  = {2},
+  pages   = {340--351},
+  doi     = {10.1016/0022-0531(82)90008-4}
+}
+
+@article{Frydman1982,
+  author  = {Frydman, Roman},
+  title   = {Towards an Understanding of Market Processes: Individual Expectations, Learning, and Convergence to Rational Expectations Equilibrium},
+  journal = {American Economic Review},
+  year    = {1982},
+  volume  = {72},
+  number  = {4},
+  pages   = {652--668}
+}
+
+@article{Grossman1981,
+  author  = {Grossman, Sanford J.},
+  title   = {An Introduction to the Theory of Rational Expectations under Asymmetric Information},
+  journal = {Review of Economic Studies},
+  year    = {1981},
+  volume  = {48},
+  number  = {4},
+  pages   = {541--559},
+  doi     = {10.2307/2297195}
+}
+
+@techreport{ArrowGreen1973,
+  author      = {Arrow, Kenneth J. and Green, Jerry R.},
+  title       = {Notes on Expectations Equilibria in Bayesian Settings},
+  year        = {1973},
+  type        = {Working Paper},
+  number      = {33},
+  institution = {Institute for Mathematical Studies in the Social Sciences, Stanford University}
+}
+
+@article{Kreps1977,
+  author  = {Kreps, David M.},
+  title   = {A Note on Fulfilled Expectations Equilibria},
+  journal = {Journal of Economic Theory},
+  year    = {1977},
+  volume  = {14},
+  number  = {1},
+  pages   = {32--43},
+  doi     = {10.1016/0022-0531(77)90083-7}
+}
+
+@article{Breeden1979,
+  author    = {Breeden, Douglas T.},
+  title     = {An Intertemporal Asset Pricing Model with Stochastic
+               Consumption and Investment Opportunities},
+  journal   = {Journal of Financial Economics},
+  year      = {1979},
+  volume    = {7},
+  number    = {3},
+  pages     = {265--296},
+  doi       = {10.1016/0304-405X(79)90016-3}
+}
+
+@book{Nummelin_1984,
+  author    = {Nummelin, Esa},
+  title     = {General Irreducible {Markov} Chains and Non-Negative
+               Operators},
+  series    = {Cambridge Tracts in Mathematics},
+  number    = {83},
+  publisher = {Cambridge University Press},
+  address   = {Cambridge},
+  year      = {1984},
+  doi       = {10.1017/CBO9780511526237}
+}
+
+@article{friedman1968role,
+  author    = {Friedman, Milton},
+  title     = {The Role of Monetary Policy},
+  journal   = {American Economic Review},
+  volume    = {58},
+  number    = {1},
+  pages     = {1--17},
+  year      = {1968}
+}
+
+@article{nelson_plosser1982,
+  author    = {Nelson, Charles R. and Plosser, Charles I.},
+  title     = {Trends and Random Walks in Macroeconomic Time Series:
+               Some Evidence and Implications},
+  journal   = {Journal of Monetary Economics},
+  volume    = {10},
+  number    = {2},
+  pages     = {139--162},
+  year      = {1982}
+}
+
+@incollection{blanchard_summers1986,
+  author    = {Blanchard, Olivier J. and Summers, Lawrence H.},
+  title     = {Hysteresis and the {European} Unemployment Problem},
+  booktitle = {NBER Macroeconomics Annual 1986, Volume 1},
+  editor    = {Fischer, Stanley},
+  publisher = {MIT Press},
+  pages     = {15--78},
+  year      = {1986}
+}
+
+@article{roed1997hysteresis,
+  author    = {Røed, Knut},
+  title     = {Hysteresis in Unemployment},
+  journal   = {Journal of Economic Surveys},
+  volume    = {11},
+  number    = {4},
+  pages     = {389--418},
+  year      = {1997}
+}
+
+@article{kapetanios_shin_snell2003,
+  author    = {Kapetanios, George and Shin, Yongcheol and Snell, Andy},
+  title     = {Testing for a Unit Root in the Nonlinear {STAR} Framework},
+  journal   = {Journal of Econometrics},
+  volume    = {112},
+  number    = {2},
+  pages     = {359--379},
+  year      = {2003}
+}
+
+@article{EpsteinWang1994,
+  author  = {Epstein, Larry G. and Wang, Tan},
+  title   = {{Intertemporal Asset Pricing under Knightian Uncertainty}},
+  journal = {Econometrica},
+  volume  = {62},
+  number  = {2},
+  pages   = {283--322},
+  year    = {1994}
+}
+
+@article{Campbell1987,
+  author  = {Campbell, John Y.},
+  title   = {{Does Saving Anticipate Declining Labor Income? An Alternative Test of the Permanent Income Hypothesis}},
+  journal = {Econometrica},
+  volume  = {55},
+  number  = {6},
+  pages   = {1249--1273},
+  year    = {1987}
+}

--- a/lectures/_toc.yml
+++ b/lectures/_toc.yml
@@ -42,8 +42,12 @@ parts:
   - file: wald_friedman_2
   - file: exchangeable
   - file: likelihood_bayes
+  - file: blackwell_kihlstrom
+  - file: information_market_equilibrium
   - file: mix_model
   - file: navy_captain
+  - file: merging_of_opinions
+  - file: survival_recursive_preferences
 - caption: 线性规划
   numbered: true
   chapters:
@@ -56,6 +60,7 @@ parts:
   - file: inventory_dynamics
   - file: linear_models
   - file: samuelson
+  - file: chow_business_cycles
   - file: kesten_processes
   - file: wealth_dynamics
   - file: kalman

--- a/lectures/blackwell_kihlstrom.md
+++ b/lectures/blackwell_kihlstrom.md
@@ -1,0 +1,1380 @@
+---
+jupytext:
+  text_representation:
+    extension: .md
+    format_name: myst
+    format_version: 0.13
+    jupytext_version: 1.16.4
+kernelspec:
+  display_name: Python 3 (ipykernel)
+  language: python
+  name: python3
+translation:
+  title: 布莱克韦尔的实验比较定理
+  headings:
+    Overview: 概述
+    Experiments and stochastic transformations: 实验与随机变换
+    Experiments and stochastic transformations::The state space and experiments: 状态空间与实验
+    Experiments and stochastic transformations::Stochastic transformations: 随机变换
+    Three equivalent criteria: 三个等价标准
+    'Three equivalent criteria::Criterion 1: the economic criterion': 标准 1：经济学标准
+    'Three equivalent criteria::Criterion 2: the sufficiency criterion': 标准 2：充分性标准
+    'Three equivalent criteria::Criterion 3: the uncertainty criterion': 标准 3：不确定性标准
+    The main theorem: 主定理
+    Kihlstrom's Bayesian interpretation: 基尔斯特罗姆的贝叶斯解释
+    Kihlstrom's Bayesian interpretation::Posteriors and standard experiments: 后验与标准实验
+    Kihlstrom's Bayesian interpretation::Mean-preserving spreads and Blackwell's order: 均值保持展开与布莱克韦尔序
+    Simulating the Blackwell order with many states: 用多状态模拟布莱克韦尔序
+    The DeGroot uncertainty function: 德格鲁特不确定性函数
+    The DeGroot uncertainty function::Concave uncertainty functions and the value of information: 凹不确定性函数与信息的价值
+    The DeGroot uncertainty function::Shannon entropy as a special case: 作为特例的香农熵
+    The DeGroot uncertainty function::Value of information as a function of experiment quality: 作为实验质量函数的信息价值
+    Connection to second-order stochastic dominance: 与二阶随机占优的关系
+    'Application 1: product quality information': 应用 1：产品质量信息
+    'Application 2: sequential experimental design': 应用 2：序贯实验设计
+    Summary: 小结
+    The Data Processing Inequality and Coarse-Graining: 数据处理不等式与粗粒化
+    The Data Processing Inequality and Coarse-Graining::The DPI for f-divergences: f-散度的 DPI
+    The Data Processing Inequality and Coarse-Graining::Connection to Blackwell's sufficiency condition: 与布莱克韦尔充分性条件的联系
+    'The Data Processing Inequality and Coarse-Graining::Information geometry: Chentsov''s theorem': 信息几何：陈氏定理
+    The Data Processing Inequality and Coarse-Graining::The information bottleneck in machine learning: 机器学习中的信息瓶颈
+    The Data Processing Inequality and Coarse-Graining::Summary of the DPI–Blackwell correspondence: DPI-布莱克韦尔对应的小结
+    Relation to Bayesian likelihood-ratio learning: 与贝叶斯似然比学习的关系
+    Relation to Bayesian likelihood-ratio learning::Summary table: 小结表
+---
+
+(blackwell_kihlstrom)=
+```{raw} jupyter
+<div id="qe-notebook-header" align="right" style="text-align:right;">
+        <a href="https://quantecon.org/" title="quantecon.org">
+                <img style="width:250px;display:inline;" width="250px" src="https://assets.quantecon.org/img/qe-menubar-logo.svg" alt="QuantEcon">
+        </a>
+</div>
+```
+
+# 布莱克韦尔的实验比较定理
+
+```{contents} Contents
+:depth: 2
+```
+
+## 概述
+
+
+
+本讲座研究 *布莱克韦尔定理*  {cite}`blackwell1951,blackwell1953` ，该定理用于对统计实验进行排序。
+
+我们的介绍引入了 {cite:t}`kihlstrom1984` 对布莱克韦尔定理的贝叶斯解释所得到的发现。
+
+布莱克韦尔和基尔斯特罗姆研究的统计模型选择问题，与本 QuantEcon 讲座 {doc}`likelihood_bayes` 中遇到的问题密切相关。
+
+为了理解其中的关联，理解布莱克韦尔的 **实验** 概念与 {doc}`likelihood_bayes` 中出现的"概率分布"或"参数化统计模型"概念之间的关系是很有帮助的。
+
+布莱克韦尔研究的情形是：一个决策者想要知道位于空间 $S$ 中的状态 $s$ 的值。
+
+对布莱克韦尔而言，**实验** 是一个 **条件概率模型**  $\{\mu(\cdot \mid s) : s \in S\}$ ，即一族由同一状态 $s \in S$ 条件化的概率分布。
+
+我们可以自由地将"状态"解释为"参数"或"参数向量"。
+
+在两状态情形 $S = \{s_1, s_2\}$ 下，两个条件密度 $f(\cdot) = \mu(\cdot \mid s_1)$ 和 $g(\cdot) = \mu(\cdot \mid s_2)$ 正是我们在本 QuantEcon 讲座 {doc}`likelihood_bayes` 以及本系列 QuantEcon 讲座中其他若干讲座中，反复用于研究经典假设检验和贝叶斯推断的那两个密度。
+
+{cite:t}`kihlstrom1984` 将 *哪个实验更具信息量？* 这一问题解释为：询问哪个条件概率模型能让一个对 $\{s_1, s_2\}$ 持有先验的贝叶斯决策者获得更高的期望效用。
+
+我们将把"信号"和"实验"作为同义词使用。
+
+因此，假设两个信号 $\tilde{x}_\mu$ 和 $\tilde{x}_\nu$ 都对未知状态 $\tilde{s}$ 具有信息量。
+
+如果每个贝叶斯决策者用 $\mu$ 都能获得弱高于用 $\nu$ 的期望效用，则称信号 $\mu$ **至少与** 信号 $\nu$ **一样具有信息量**。
+
+这个经济学标准等价于两个统计学标准：
+
+- *充分性*（布莱克韦尔）： $\tilde{x}_\nu$ 可以通过对 $\tilde{x}_\mu$ 进行额外的随机化来生成。
+- *不确定性降低*（ {cite:t}`degroot1962` ）：对每个凹的不确定性函数而言， $\tilde{x}_\mu$ 至少与 $\tilde{x}_\nu$ 一样降低了期望不确定性。
+
+基尔斯特罗姆的表述聚焦于 *后验分布*。
+
+更具信息量的实验会生成在凸序意义下更为分散的后验分布。
+
+在两状态情形下，这就变成了在 $[0, 1]$ 上的均值保持展开比较，可以用检验二阶随机占优的积分 CDF 检验来验证。
+
+本讲座的进行方式如下：
+
+1. 建立记号并将实验定义为马尔可夫矩阵。
+2. 用马尔可夫核定义随机变换。
+3. 陈述三个等价标准。
+4. 陈述主定理并勾勒其证明。
+5. 通过标准实验和均值保持展开建立贝叶斯解释。
+6. 用 Python 模拟来阐释每个概念。
+
+我们先进行一些导入。
+
+```{code-cell} ipython3
+import numpy as np
+import matplotlib.pyplot as plt
+from scipy.optimize import minimize
+import matplotlib as mpl  # i18n
+FONTPATH = "fonts/SourceHanSerifSC-SemiBold.otf"  # i18n
+mpl.font_manager.fontManager.addfont(FONTPATH)  # i18n
+mpl.rcParams['font.family'] = ['Source Han Serif SC']  # i18n
+```
+
+## 实验与随机变换
+
+### 状态空间与实验
+
+设 $S = \{s_1, \ldots, s_N\}$ 为世界可能状态的有限集合。
+
+一个 **实验** 由观测信号 $\tilde{x}$ 在给定状态 $\tilde{s}$ 下的条件分布来描述。
+
+当信号空间也是有限的，比如 $X = \{x_1, \ldots, x_M\}$ 时，一个实验就归结为一个 $N \times M$ 的 *马尔可夫矩阵*
+
+$$
+\mu = [\mu_{ij}], \qquad
+\mu_{ij} = \Pr(\tilde{x}_\mu = x_j \mid \tilde{s} = s_i) \geq 0,
+\quad \sum_{j=1}^{M} \mu_{ij} = 1 \;\forall\, i.
+$$
+
+每一行 $i$ 给出了当真实状态为 $s_i$ 时的信号分布。
+
+
+```{code-cell} ipython3
+μ = np.array([[0.6, 0.3, 0.1],
+              [0.1, 0.3, 0.6]])
+
+Q = np.array([[1.0, 0.0],
+              [0.5, 0.5],
+              [0.0, 1.0]])
+
+ν = μ @ Q
+
+print("实验 μ（3 个信号，各行之和为 1）：")
+print(μ)
+print("\n随机变换 Q（3 × 2）：")
+print(Q)
+print("\n实验 ν = μ @ Q（2 个信号）：")
+print(ν)
+print("\nμ 的行和：", μ.sum(axis=1))
+print("ν 的行和：", ν.sum(axis=1))
+```
+
+### 随机变换
+
+**随机变换**  $Q$ 通过进一步的随机化将一个实验的信号映射为另一个实验的信号。
+
+在具有 $M$ 个输入信号和 $K$ 个输出信号的离散设定下， $Q$ 是一个 $M \times K$ 的马尔可夫矩阵：对每一行 $l$ 有 $q_{lk} \geq 0$ 且 $\sum_k q_{lk} = 1$ 。
+
+```{prf:definition} 充分性
+:label: def-sufficiency
+
+如果存在一个随机变换 $Q$ （一个 $M \times K$ 的马尔可夫矩阵）使得
+
+$$
+\nu = \mu \, Q,
+$$
+
+则称实验 $\mu$  *对*  $\nu$ *充分*，这意味着一个观测到 $\tilde{x}_\mu$ 的观察者可以通过将其信号传递给 $Q$ 来生成 $\tilde{x}_\nu$ 的分布。
+```
+
+如果你观测到更具信息量的信号 $\tilde{x}_\mu$ ，那么你总是可以 *丢弃* 信息来重现一个信息量较少的信号。
+
+反过来则不可能：一个信息量较少的信号无法被丰富到恢复出所丢失的信息。
+
+我们可以用上面定义的两个实验 $\mu$ 和 $\nu$ 来进行数值验证。
+
+下面的函数搜索一个使 $\|\nu - \mu \, Q\|$ 最小化的随机变换 $Q$ 。
+
+如果存在一个精确的 $Q$ ，残差将接近于零；否则残差会很大。
+
+```{code-cell} ipython3
+def find_stochastic_transform(μ, ν, tol=1e-8):
+    """
+    寻找一个行随机矩阵 Q，使 ||ν - μ @ Q|| 最小化。
+    """
+    _, M = μ.shape
+    _, K = ν.shape
+
+    def unpack(q_flat):
+        return q_flat.reshape(M, K)
+
+    def objective(q_flat):
+        Q = unpack(q_flat)
+        return np.linalg.norm(ν - μ @ Q)**2
+
+    constraints = [
+        {"type": "eq", "fun": lambda q_flat, 
+        row=i: unpack(q_flat)[row].sum() - 1.0}
+        for i in range(M)
+    ]
+    bounds = [(0.0, 1.0)] * (M * K)
+    Q0 = np.full((M, K), 1 / K).ravel()
+
+    result = minimize(
+        objective,
+        Q0,
+        method="SLSQP",
+        bounds=bounds,
+        constraints=constraints,
+        options={"ftol": tol, "maxiter": 1_000},
+    )
+
+    Q = unpack(result.x)
+    residual = np.linalg.norm(ν - μ @ Q)
+    return Q, residual
+
+# 正向：寻找使 ν = μ @ Q 的 Q（应当成功）
+Q_fwd, res_fwd = find_stochastic_transform(μ, ν)
+print("正向（μ 到 ν）：")
+print(f"  残差 = {res_fwd:.2e}")
+print(f"  存在精确变换：{res_fwd < 1e-6}")
+
+# 反向：寻找使 μ = ν @ Q' 的 Q'（应当失败）
+Q_rev, res_rev = find_stochastic_transform(ν, μ)
+print("\n反向（ν 到 μ）：")
+print(f"  残差 = {res_rev:.2e}")
+print(f"  存在精确变换：{res_rev < 1e-6}")
+```
+
+正向残差接近于零：存在一个从 $\mu$ 到 $\nu$ 的随机变换，这证实了 $\mu$ 对 $\nu$ 充分。
+
+反向残差很大：没有任何随机变换能从 $\nu$ 恢复出 $\mu$ 。
+
+没有任何随机变换能够撤销这种信息损失。
+
+关键在于，随机变换的逆一般来说并不是一个随机变换。
+
+事实上，唯一其逆也是随机变换的随机变换是置换矩阵，它仅仅重新标记信号而不损失任何信息。
+
+## 三个等价标准
+
+布莱克韦尔定理确立了比较实验的三种不同方式最终都是等价的。
+
+### 标准 1：经济学标准
+
+第一个标准通过实验对决策者的价值来比较实验。
+
+设 $A$ 为一个紧凸的行动集合， $u: A \times S \to \mathbb{R}$ 为一个有界效用函数。
+
+决策者观测到 $x \in X$ ，通过贝叶斯规则更新对 $\tilde{s}$ 的信念，并选择 $d(x) \in A$ 以最大化期望效用。
+
+设 $p = (p_1, \ldots, p_N)$ 为状态上的先验，并记
+
+$$
+P = \bigl\{(p_1, \ldots, p_N) : p_i \geq 0,\; \textstyle\sum_i p_i = 1\bigr\}
+$$
+
+为概率单纯形。
+
+对固定的 $A$ 和 $u$ ，在实验 $\mu$ 下的 *可达期望效用向量集合* 为
+
+$$
+B(\mu, A, u) = \Bigl\{v \in \mathbb{R}^N :
+  v_i = \textstyle\int_X u(f(x), s_i)\,\mu_i(dx)
+  \text{ for some measurable } f: X \to A \Bigr\}.
+$$
+
+```{prf:definition} 经济学标准
+:label: def-economic-criterion
+
+如果对每个紧凸行动集 $A$ 和每个有界效用函数 $u: A \times S \to \mathbb{R}$ 都有
+
+$$
+B(\mu, A, u) \supseteq B(\nu, A, u)
+$$
+
+则称 $\mu$ 在经济学意义上 **至少与** $\nu$ **一样具有信息量**。
+```
+
+这个标准说的是：如果决策者在看到 $\nu$ 后所能达到的任何结果，在看到 $\mu$ 后也都能达到，那么实验 $\mu$ 就优于实验 $\nu$ 。
+
+其原因在于，一个更具信息量的实验允许决策者通过 *忽略* 或 *混淆* 部分额外信息来模仿一个信息量较少的实验。
+
+但反过来则未必可能。
+
+因此 $B(\mu, A, u) \supseteq B(\nu, A, u)$ 意味着 $\mu$ 给决策者提供的可行期望效用结果至少与 $\nu$ 一样多。
+
+等价地，对每个先验 $p \in P$ ，每个贝叶斯决策者用 $\tilde{x}_\mu$ 都能获得弱高于用 $\tilde{x}_\nu$ 的期望效用。
+
+### 标准 2：充分性标准
+
+第二个标准使用了上面引入的随机变换思想。
+
+```{prf:definition} 布莱克韦尔充分性
+:label: def-blackwell-sufficiency
+
+如果存在一个从 $\mu$ 的信号空间到 $\nu$ 的信号空间的随机变换 $Q$ ，使得
+
+$$
+\nu_i(E) = (Q \circ \mu_i)(E)
+\quad \forall\, E \in \mathscr{G},\; i = 1, \ldots, N.
+$$
+
+则称 $\mu \geq \nu$ 在布莱克韦尔意义下成立。
+```
+
+对有限实验，用矩阵记号表示： $\nu = \mu \, Q$ 。
+
+### 标准 3：不确定性标准
+
+第三个标准通过实验对状态不确定性的降低程度来比较实验。
+
+{cite:t}`degroot1962` 把任何凹函数 $U: P \to \mathbb{R}$ 称为 **不确定性函数**。
+
+典型的例子是香农熵：
+
+$$
+U(p) = -\sum_{i=1}^{N} p_i \log p_i.
+$$
+
+```{prf:definition} 德格鲁特不确定性标准
+:label: def-degroot-uncertainty
+
+如果对每个先验 $p \in P$ 和每个凹函数 $U: P \to \mathbb{R}$ 都有
+
+$$
+\int_P U(q)\,\hat\mu^p(dq)
+\;\leq\;
+\int_P U(q)\,\hat\nu^p(dq),
+$$
+
+其中 $\hat\mu^p$ 是实验 $\mu$ 在先验 $p$ 下诱导的后验信念分布，则称 $\mu$ **至少与** $\nu$ **一样地降低了期望不确定性**。
+```
+
+为看清这一点，设 $Q = p^\mu(X)$ 表示由实验 $\mu$ 诱导的随机后验。
+
+那么 $Q$ 服从分布 $\hat\mu^p$ ，因此
+
+$$
+\mathbb{E}[U(Q)] = \int_P U(q)\,\hat\mu^p(dq).
+$$
+
+由于 $U$ 是凹的，詹森不等式给出
+
+$$
+\mathbb{E}[U(Q)] \leq U(\mathbb{E}[Q]) = U(p).
+$$
+
+因此
+
+$$
+\int_P U(q)\,\hat\mu^p(dq) \leq U(p),
+$$
+
+所以任何实验都会弱地降低期望不确定性。
+
+基尔斯特罗姆的标准实验构造稍后会让我们在均匀先验 $c = (1 / N, \ldots, 1 / N)$ 下比较后验分布。
+
+## 主定理
+
+```{prf:theorem} 布莱克韦尔定理
+:label: thm-blackwell
+
+以下三个条件等价：
+
+(i) 经济学标准：对每个紧凸 $A$ 和每个有界效用函数 $u$ 都有 $B(\mu, A, u) \supseteq B(\nu, A, u)$ 。
+
+(ii) 充分性标准：存在一个从 $\mu$ 的信号空间到 $\nu$ 的信号空间的随机变换 $Q$ ，使得 $\nu = Q \circ \mu$ 。
+
+(iii) 不确定性标准：对每个先验 $p \in P$ 和每个凹函数 $U$ 都有 $\int_P U(q)\,\hat\mu^p(dq) \leq \int_P U(q)\,\hat\nu^p(dq)$ 。
+```
+
+另见 {cite:t}`blackwell1951` 、 {cite:t}`bonnenblust1949` 和 {cite:t}`degroot1962` 。
+
+最困难的部分是经济学标准与充分性标准之间的等价性。
+
+*概要（ii $\Rightarrow$ i）：* 如果 $\nu = \mu Q$ ，那么任何基于 $\tilde{x}_\nu$ 的决策规则都可以通过如下方式复现：先观测 $\tilde{x}_\mu$ ，再从 $Q$ 中抽取一个合成的 $\tilde{x}_\nu$ ，然后应用同样的规则。
+
+*概要（i $\Rightarrow$ ii）：* 由于对每个 $A$ 和 $u$ 都有 $B(\mu, A, u) \supseteq B(\nu, A, u)$ ，一个分离超平面（对偶）论证意味着存在一个后验空间中的均值保持核 $D$ ，将 $\nu$ 的标准实验送入 $\mu$ 的标准实验。再从这些后验律回到原始信号空间就得到所需的混淆 $Q$ ，满足 $\nu = \mu Q$ 。因此 $D$ 是后验信念上的中间随机化，而非字面意义上的信号空间核 $Q$ 。
+
+*概要（ii $\Rightarrow$ iii）：* 在混淆之下，较粗实验的后验是较细实验后验的条件期望，因此詹森不等式对每个凹函数 $U$ 都给出该结果。
+
+*概要（iii $\Rightarrow$ ii）：* 其逆命题，即对所有凹函数 $U$ 的不等式迫使 $Q$ 存在，在 {cite}`blackwell1953` 中得到证明。基尔斯特罗姆基于后验的表示使这一几何变得透明。
+
+## 基尔斯特罗姆的贝叶斯解释
+
+### 后验与标准实验
+
+基尔斯特罗姆分析中的关键对象是 *后验信念向量*。
+
+当先验 $p$ 成立且实验 $\mu$ 产生信号 $x$ 时，贝叶斯规则给出
+
+$$
+p_i^\mu(x) = \Pr(\tilde{s} = s_i \mid \tilde{x}_\mu = x)
+= \frac{\mu_{ix} \, p_i}{\sum_j \mu_{jx}\, p_j}, \qquad i = 1, \ldots, N.
+$$
+
+后验 $p^\mu(x) \in P$ 是单纯形中的一个随机点。
+
+```{prf:property} 均值保持
+:label: prop-mean-preservation
+
+先验 $p$ 是后验的期望：
+
+$$
+\mathbb{E}[p^\mu] = \sum_x \Pr(\tilde{x}_\mu = x)\, p^\mu(x) = p.
+$$
+
+这有时被称为 *信念的迭代期望定律*。
+```
+
+对固定的先验 $c$ ，基尔斯特罗姆的 **标准实验** 用 $\mu$ 所生成的后验信念来替换其原始信号。
+
+设 $\hat\mu^c$ 表示由 $\mu$ 在先验 $c$ 下诱导的后验分布。
+均值保持意味着 $\int_P q \, \hat\mu^c(dq) = c$ 。
+
+当两个实验诱导相同的后验分布时，称它们 **信息等价**。
+
+标准实验剥离了信号除后验以外的所有细节，因此它提供了用于比较实验的一个规范的贝叶斯表示。
+
+后验信念上的随机核存在于单纯形 $P$ 上，而布莱克韦尔混淆 $Q$ 存在于原始信号空间上。基尔斯特罗姆的构造使用前者来研究凸序，然后在过渡到标准实验之后恢复后者。
+
+任何两个生成相同后验分布的实验，都会导致每个贝叶斯决策者做出完全相同的决策，无论它们的原始信号空间看起来多么不同。
+
+### 均值保持展开与布莱克韦尔序
+
+基尔斯特罗姆的关键重述如下。
+
+```{prf:theorem} 基尔斯特罗姆的重述
+:label: thm-kihlstrom
+
+$\mu \geq \nu$ 在布莱克韦尔意义下成立，当且仅当 $\hat\mu^c$ 是 $\hat\nu^c$ 的一个
+**均值保持展开**；即，对每个凸函数 $g: P \to \mathbb{R}$ 都有
+
+$$
+\int_P g(p)\,\hat\mu^c(dp) \;\geq\; \int_P g(p)\,\hat\nu^c(dp)
+$$
+
+。
+```
+
+等价地， $\hat\mu^c$ 在凸序意义下大于 $\hat\nu^c$ 。
+
+一个更好的实验会将后验信念推向离先验更远的地方，同时保持它们的均值不变。
+
+为了具体地看到这一点，我们为两状态情形定义两个实验并计算它们的后验。
+
+```{code-cell} ipython3
+def compute_posteriors(μ, prior, tol=1e-14):
+    """
+    为每个信号实现计算后验分布。
+    """
+    N, M = μ.shape
+    signal_probs = μ.T @ prior
+    numerators = μ.T * prior
+    posteriors = np.zeros((M, N))
+    np.divide(
+        numerators,
+        signal_probs[:, None],
+        out=posteriors,
+        where=signal_probs[:, None] > tol,
+    )
+    return posteriors, signal_probs
+
+
+def check_mean_preservation(posteriors, signal_probs, prior):
+    """验证 E[后验] == 先验。"""
+    expected_posterior = (posteriors * signal_probs[:, None]).sum(axis=0)
+    return expected_posterior, np.allclose(expected_posterior, prior)
+
+
+N = 2
+prior = np.array([0.5, 0.5])
+
+μ_info = np.array([[0.8, 0.2],
+                   [0.2, 0.8]])
+
+ν_info = np.array([[0.6, 0.4],
+                   [0.4, 0.6]])
+
+post_μ, probs_μ = compute_posteriors(μ_info, prior)
+post_ν, probs_ν = compute_posteriors(ν_info, prior)
+
+print("实验 μ（更具信息量）：\n")
+print("信号概率：", probs_μ.round(3))
+print("后验（行 = 信号，列 = 状态）：")
+print(post_μ.round(3))
+mean_μ, ok_μ = check_mean_preservation(post_μ, probs_μ, prior)
+print(f"E[后验] = {mean_μ.round(4)}  （等于先验：{ok_μ}）")
+
+print("\n 实验 ν（信息量较少）：\n")
+print("信号概率：", probs_ν.round(3))
+print("后验：")
+print(post_ν.round(3))
+mean_ν, ok_ν = check_mean_preservation(post_ν, probs_ν, prior)
+print(f"E[后验] = {mean_ν.round(4)}  （等于先验：{ok_ν}）")
+```
+
+对 $N = 2$ 个状态，单纯形 $P$ 是单位区间 $[0, 1]$ （状态 $s_1$ 的概率）。
+
+我们可以直接绘制在实验 $\mu$ 和 $\nu$ 下的后验分布。
+
+```{code-cell} ipython3
+---
+mystnb:
+  figure:
+    caption: 两状态情形下的后验分布
+    name: fig-blackwell-two-state-posteriors
+---
+def plot_posterior_distributions(μ_matrix, ν_matrix, prior,
+                                 labels=("μ（更具信息量）",
+                                         "ν（信息量较少）")):
+    """
+    对两状态实验，绘制 [0,1] 上的后验分布
+    （即标准实验分布）。
+    """
+    posts_μ, probs_μ = compute_posteriors(μ_matrix, prior)
+    posts_ν, probs_ν = compute_posteriors(ν_matrix, prior)
+
+    fig, axes = plt.subplots(1, 2, figsize=(11, 4), sharey=False)
+    prior_val = prior[0]
+
+    for ax, posts, probs, label in zip(
+        axes, [posts_μ, posts_ν], [probs_μ, probs_ν], labels):
+        p_s1 = posts[:, 0]
+        ax.vlines(p_s1, 0, probs, linewidth=6, color="steelblue", alpha=0.7)
+        ax.axvline(prior_val, color="tomato", linestyle="--", linewidth=2,
+                   label=f"先验 = {prior_val:.2f}")
+        ax.set_xlim(0, 1)
+        ax.set_xlabel(r"后验 $p(s_1 \mid x)$", fontsize=12)
+        ax.set_ylabel("概率质量", fontsize=12)
+        mean_post = (p_s1 * probs).sum()
+        ax.axvline(mean_post, color="green", linestyle=":", linewidth=2,
+                   label=f"E[后验] = {mean_post:.2f}")
+        ax.text(0.03, 0.94, label, transform=ax.transAxes, va="top")
+        ax.legend()
+
+    plt.tight_layout()
+    plt.show()
+
+plot_posterior_distributions(μ_info, ν_info, prior)
+```
+
+这就是均值保持展开的实际体现：两个分布具有相同的均值（等于先验），但更具信息量的实验 $\mu$ 将其后验展开得更远。
+
+我们可以数值地验证均值保持展开条件。
+
+关键事实在于，至多相差一个仿射项，任何凸函数都可以表示为"看涨期权"收益 $g_t(p) = \max(p - t, 0)$ 的混合。
+
+由于被比较的两个后验分布具有相同的均值，那个仿射项在比较中会相互抵消。
+
+因此只需对所有阈值 $t \in [0, 1]$ 检验 $E[g_t(p^\mu)] \geq E[g_t(p^\nu)]$ 即可。
+
+```{code-cell} ipython3
+---
+mystnb:
+  figure:
+    caption: 两状态情形下的凸序检验
+    name: fig-blackwell-convex-order-check
+---
+def check_mps_convex_functions(μ_matrix, ν_matrix, prior, n_functions=200):
+    """
+    使用凸函数 g(p) = max(p - t, 0) 验证
+    均值保持展开条件。
+    """
+    posts_μ, probs_μ = compute_posteriors(μ_matrix, prior)
+    posts_ν, probs_ν = compute_posteriors(ν_matrix, prior)
+
+    p_μ = posts_μ[:, 0]
+    p_ν = posts_ν[:, 0]
+
+    thresholds = np.linspace(0, 1, n_functions)
+    diffs = []
+    for t in thresholds:
+        Eg_μ = (np.maximum(p_μ - t, 0) * probs_μ).sum()
+        Eg_ν = (np.maximum(p_ν - t, 0) * probs_ν).sum()
+        diffs.append(Eg_μ - Eg_ν)
+
+    fig, ax = plt.subplots(figsize=(8, 4))
+    ax.plot(thresholds, diffs, color="steelblue", linewidth=2)
+    ax.axhline(0, color="tomato", linestyle="--", linewidth=2)
+    ax.fill_between(thresholds, diffs, 0,
+                    where=np.array(diffs) >= 0,
+                    alpha=0.25, color="steelblue",
+                    label="$E[g(p^μ)] - E[g(p^ν)] \\geq 0$")
+    ax.set_xlabel("阈值 $t$", fontsize=12)
+    ax.set_ylabel(r"$E[\max(p-t,0)]$ 差值", fontsize=12)
+    ax.legend(fontsize=11)
+    plt.tight_layout()
+    plt.show()
+
+    all_non_negative = all(d >= -1e-10 for d in diffs)
+    print(f"μ 是 ν 的均值保持展开：{all_non_negative}")
+    return diffs
+
+_ = check_mps_convex_functions(μ_info, ν_info, prior)
+```
+
+差值 $E[g_t(p^\mu)] - E[g_t(p^\nu)]$ 对每个阈值 $t$ 都是非负的，这证实了 $\hat\mu^c$ 是 $\hat\nu^c$ 的均值保持展开，因此在布莱克韦尔序中 $\mu \geq \nu$ 。
+
+## 用多状态模拟布莱克韦尔序
+
+我们现在转到一个三状态的例子。
+
+实验 $\mu$ 与状态强相关，而实验 $\nu$ 是 $\mu$ 的一个混淆。
+
+```{code-cell} ipython3
+N3 = 3
+prior3 = np.array([1/3, 1/3, 1/3])
+
+μ3 = np.array([[0.7, 0.2, 0.1],
+               [0.1, 0.7, 0.2],
+               [0.2, 0.1, 0.7]])
+
+Q3 = np.array([[0.9, 0.05, 0.05],
+               [0.05, 0.8, 0.15],
+               [0.05, 0.15, 0.8]])
+
+ν3 = μ3 @ Q3
+
+print("μ (3×3)：")
+print(np.round(μ3, 2))
+print("\nQ（混淆）：")
+print(np.round(Q3, 2))
+print("\nν = μ @ Q：")
+print(np.round(ν3, 3))
+```
+
+
+对三个状态，后验信念存在于一个 2-单纯形中。
+
+让我们可视化在 $\mu$ 和 $\nu$ 下采样的后验点
+
+```{code-cell} ipython3
+---
+mystnb:
+  figure:
+    caption: 2-单纯形上采样的后验点
+    name: fig-blackwell-simplex-clouds
+---
+def sample_posteriors(μ_matrix, prior, n_draws=3000, rng=None):
+    """
+    从实验中模拟 n_draws 个观测并计算
+    由此得到的后验信念。
+    返回形状为 (n_draws, N) 的数组。
+    """
+    if rng is None:
+        rng = np.random.default_rng()
+    N, M = μ_matrix.shape
+    states = rng.choice(N, size=n_draws, p=prior)
+    signals = np.array([rng.choice(M, p=μ_matrix[s]) for s in states])
+    posteriors, _ = compute_posteriors(μ_matrix, prior)
+    return posteriors[signals]
+
+
+def simplex_to_cart(pts):
+    """将 3-单纯形重心坐标转换为二维笛卡尔坐标。"""
+    corners = np.array([[0.0, 0.0],
+                        [1.0, 0.0],
+                        [0.5, np.sqrt(3)/2]])
+    return pts @ corners
+
+
+def plot_simplex_posteriors(μ_matrix, ν_matrix, prior3, n_draws=3000, seed=0):
+    rng = np.random.default_rng(seed)
+    posts_μ = sample_posteriors(μ_matrix, prior3, n_draws, rng=rng)
+    posts_ν = sample_posteriors(ν_matrix, prior3, n_draws, rng=rng)
+
+    cart_μ = simplex_to_cart(posts_μ)
+    cart_ν = simplex_to_cart(posts_ν)
+    prior_cart = simplex_to_cart(prior3[None, :])[0]
+
+    corners = np.array([[0.0, 0.0],
+                        [1.0, 0.0],
+                        [0.5, np.sqrt(3)/2]])
+
+    fig, axes = plt.subplots(1, 2, figsize=(12, 5))
+    panel_labels = ["μ（更具信息量）", "ν（被混淆）"]
+    data = [(cart_μ, "steelblue"), (cart_ν, "darkorange")]
+    labels = ["$s_1$", "$s_2$", "$s_3$"]
+    offsets = [(-0.07, -0.05), (0.02, -0.05), (-0.02, 0.03)]
+
+    for ax, (cart, c), panel_label in zip(axes, data, panel_labels):
+        tri = plt.Polygon(corners, fill=False, edgecolor="black", linewidth=2)
+        ax.add_patch(tri)
+        ax.scatter(cart[:, 0], cart[:, 1], s=4, alpha=0.25, color=c)
+        ax.scatter(*prior_cart, s=120, color="red", zorder=5,
+                   label="先验", marker="*")
+        for i, (lbl, off) in enumerate(zip(labels, offsets)):
+            ax.text(corners[i][0] + off[0], corners[i][1] + off[1],
+                    lbl, fontsize=13)
+        ax.set_xlim(-0.15, 1.15)
+        ax.set_ylim(-0.1, np.sqrt(3)/2 + 0.1)
+        ax.set_aspect("equal")
+        ax.set_xticks([])
+        ax.set_yticks([])
+        ax.text(0.03, 0.94, panel_label, transform=ax.transAxes, va="top")
+        ax.legend(fontsize=11, loc="upper right")
+
+    plt.tight_layout()
+    plt.show()
+
+plot_simplex_posteriors(μ3, ν3, prior3)
+```
+
+由于这个例子只有三个信号，每个面板由重复采样的三个后验原子构成，而非一个连续的点云。
+
+在 $\mu$ 下，采样的后验点向顶点延伸得更远。
+
+在被混淆的实验 $\nu$ 下，采样的后验点更靠近中心。
+
+## 德格鲁特不确定性函数
+
+### 凹不确定性函数与信息的价值
+
+{cite}`degroot1962` 通过 **不确定性函数**  $U: P \to \mathbb{R}$ 将信息的价值形式化。
+
+在德格鲁特的公理化中，不确定性函数是：
+
+- *凹的*：由詹森不等式，观测任何信号都弱地降低期望不确定性。
+- *对称的*：它依赖于 $p$ 的各分量，而不依赖于它们的标记。
+- *归一化的*：它在 $p = (1/N, \ldots, 1/N)$ 处取最大值，在顶点处取最小值。
+
+*在给定先验 $p$ 下实验 $\mu$ 的价值* 为
+
+$$
+I(\tilde{x}_\mu;\, \tilde{s};\, U)
+= U(p) - \mathbb{E}[U(p^\mu)],
+$$
+
+这个量是不确定性的期望降低量。
+
+布莱克韦尔序等价于以下陈述：对 *每个* 凹函数 $U$ 都有 $I(\tilde{x}_\mu; \tilde{s}; U) \geq I(\tilde{x}_\nu; \tilde{s}; U)$ 。
+
+### 作为特例的香农熵
+
+规范的不确定性函数是香农熵
+
+$$
+U_H(p) = -\sum_{i=1}^{N} p_i \log p_i.
+$$
+
+在均匀先验 $c = (1/N, \ldots, 1/N)$ 下，德格鲁特的价值公式变为
+
+$$
+I(\tilde{x}_\mu, c;\, U_H)
+= \log N - H(\tilde{s} \mid \tilde{x}_\mu),
+$$
+
+其中 $H(\tilde{s} \mid \tilde{x}_\mu)$ 是给定信号时状态的条件熵。
+
+要看清原因，将 $H(\tilde{s} \mid \tilde{x}_\mu) = \sum_x \Pr(\tilde{x}_\mu = x) \, H(\tilde{s} \mid \tilde{x}_\mu = x)$ 写出，其中每个条件熵项等于 $-\sum_i p_i^\mu(x) \log p_i^\mu(x) = U_H(p^\mu(x))$ 。
+
+代入德格鲁特公式得到 $I = U_H(c) - \mathbb{E}[U_H(p^\mu)] = \log N - H(\tilde{s} \mid \tilde{x}_\mu)$ ，这正是 $\tilde{x}_\mu$ 与 $\tilde{s}$ 之间的 *互信息*。
+
+```{note}
+布莱克韦尔序蕴含基于熵的不等式，但 *其逆命题不成立*：仅凭熵无法确定完整的布莱克韦尔序。
+
+两个实验可以具有相同的互信息却在布莱克韦尔排序中不同，因为单个凹函数无法检测出后验分散度上的所有差异。
+
+完整的布莱克韦尔序要求不等式对 *每个* 凹函数 $U$ 都成立，而不仅仅是香农熵。
+```
+
+```{code-cell} ipython3
+def entropy(p, ε=1e-12):
+    """概率向量的香农熵。"""
+    p = np.asarray(p, dtype=float)
+    p = np.clip(p, ε, 1.0)
+    return -np.sum(p * np.log(p))
+
+
+def degroot_value(μ_matrix, prior, U_func):
+    """
+    计算德格鲁特信息价值 I = U(先验) - E[U(后验)]。
+    """
+    posts, probs = compute_posteriors(μ_matrix, prior)
+    prior_uncertainty = U_func(prior)
+    expected_post_uncertainty = sum(
+        probs[j] * U_func(posts[j]) for j in range(len(probs)))
+    return prior_uncertainty - expected_post_uncertainty
+
+
+def gini_impurity(p):
+    """基尼不纯度：1 - sum(p_i^2)。"""
+    return 1.0 - np.sum(np.asarray(p)**2)
+
+
+def tsallis_entropy(p, q=2):
+    """q 阶查理斯熵（q>1 时为凹）。"""
+    p = np.clip(p, 1e-12, 1.0)
+    return (1 - np.sum(p**q)) / (q - 1)
+
+
+def tsallis_q15(p):
+    """q=1.5 的查理斯熵，用于独立的凹性检验。"""
+    return tsallis_entropy(p, q=1.5)
+
+
+def sqrt_index(p):
+    """基于 sum(sqrt(p_i)) 的凹不确定性指数。"""
+    p = np.clip(np.asarray(p), 0.0, 1.0)
+    return np.sum(np.sqrt(p)) - 1.0
+
+uncertainty_functions = {
+    "Shannon entropy": entropy,
+    "Gini impurity": gini_impurity,
+    "Tsallis (q=1.5)": tsallis_q15,
+    "Square-root index": sqrt_index,
+}
+
+header = (f"{'Uncertainty function':<22}  "
+          f"{'I(μ)':<10}  {'I(ν)':<10}  "
+          f"{'I(μ)>=I(ν)?'}")
+print(header)
+print("-" * 58)
+for name, U in uncertainty_functions.items():
+    I_μ = degroot_value(μ_info, prior, U)
+    I_ν = degroot_value(ν_info, prior, U)
+    print(f"{name:<22}  {I_μ:<10.4f}  {I_ν:<10.4f}  {I_μ >= I_ν - 1e-10}")
+```
+
+正如定理所预测的那样，一旦我们知道 $\mu \geq \nu$ 在布莱克韦尔意义下成立，那么对每个凹不确定性函数都有 $I(\mu) \geq I(\nu)$ 。
+
+### 作为实验质量函数的信息价值
+
+我们现在将介于无信息量和完全有信息量之间的实验连续统参数化。
+
+对 $N = 2$ 个状态，一个自然的族是
+
+$$
+\mu(\theta) = (1 - \theta) \cdot \tfrac{1}{2}\mathbf{1}\mathbf{1}^\top
+             + \theta \cdot I_2,
+\quad \theta \in [0, 1],
+$$
+
+第一项是完全混合的矩阵， $I_2$ 是单位矩阵。
+
+```{code-cell} ipython3
+---
+mystnb:
+  figure:
+    caption: 信息价值与实验质量
+    name: fig-blackwell-value-by-quality
+---
+def make_experiment(θ, N=2):
+    """参数化实验：θ=0 无信息量，θ=1 完全有信息量。"""
+    return (1 - θ) * np.ones((N, N)) / N + θ * np.eye(N)
+
+
+θs = np.linspace(0, 1, 100)
+prior2 = np.array([0.5, 0.5])
+
+fig, ax = plt.subplots(figsize=(9, 4))
+for name, U in uncertainty_functions.items():
+    values = [degroot_value(make_experiment(θ), prior2, U) for θ in θs]
+    vmin, vmax = values[0], values[-1]
+    normed = (np.array(values) - vmin) / (vmax - vmin + 1e-15)
+    ax.plot(θs, normed, label=name, linewidth=2)
+
+ax.set_xlabel("实验质量 θ（0 = 无信息量，1 = 完全有信息量）",
+              fontsize=11)
+ax.set_ylabel("归一化信息价值 I(μ(θ))", fontsize=11)
+ax.legend(fontsize=10)
+plt.tight_layout()
+plt.show()
+```
+
+每个凹不确定性函数都会给更具信息量的实验赋予弱更高的价值。
+
+## 与二阶随机占优的关系
+
+如果对每个凹函数 $u$ 都有 $E[u(X)] \geq E[u(Y)]$ ，则称随机变量 $X$ **二阶随机占优**
+$Y$ （记作 $X \succeq_{\text{SOSD}} Y$ ）。
+等价地， $Y$ 是 $X$ 的一个均值保持展开。
+
+不确定性函数表示使得与 SOSD 的联系变得明确。
+
+由于 $U$ 是凹的， $-U$ 是凸的，因此条件
+
+$$
+\mathbb{E}[U(p^\mu)] \leq \mathbb{E}[U(p^\nu)] \quad \text{for all concave } U
+$$
+
+正是 $\hat\mu^c$ 在 $P$ 上以凸序占优 $\hat\nu^c$ 的陈述。
+
+当 $N = 2$ 时，后验信念是 $[0, 1]$ 中的标量，SOSD 比较简化为经典的积分 CDF 检验。
+
+具体地， $\hat\mu^c$ 是 $\hat\nu^c$ 的均值保持展开，当且仅当对所有 $t \in [0,1]$ 都有 $\int_0^t F_\mu(s)\,ds \geq \int_0^t F_\nu(s)\,ds$ ，其中 $F_\mu$ 和 $F_\nu$ 是每个实验下 $s_1$ 后验的 CDF。等价地，用 SOSD 的语言来说，$\nu$ 下信息量较少的后验占优于 $\mu$ 下更为分散的后验。
+
+我们可以对上面的两状态例子在图形上验证这一点
+
+```{code-cell} ipython3
+---
+mystnb:
+  figure:
+    caption: 两状态情形下的积分 CDF 检验
+    name: fig-blackwell-integrated-cdf
+---
+def cdf_data_1d(weights, values):
+    """对离散分布排序支撑点和累积质量。"""
+    idx = np.argsort(values)
+    sorted_vals = values[idx]
+    sorted_wts = weights[idx]
+    cum_mass = np.cumsum(sorted_wts)
+    return sorted_vals, cum_mass
+
+
+def plot_sosd_posteriors(μ_matrix, ν_matrix, prior):
+    """为 s1 上的后验分布绘制 CDF 和积分 CDF。"""
+    posts_μ, probs_μ = compute_posteriors(μ_matrix, prior)
+    posts_ν, probs_ν = compute_posteriors(ν_matrix, prior)
+
+    p_μ = posts_μ[:, 0]
+    p_ν = posts_ν[:, 0]
+
+    sv_μ, cm_μ = cdf_data_1d(probs_μ, p_μ)
+    sv_ν, cm_ν = cdf_data_1d(probs_ν, p_ν)
+
+    fig, axes = plt.subplots(1, 2, figsize=(11, 4))
+
+    ax = axes[0]
+    for sv, cm, lbl, c in [(sv_μ, cm_μ, "μ", "steelblue"),
+                           (sv_ν, cm_ν, "ν", "darkorange")]:
+        xs = np.concatenate([[0], sv, [1]])
+        ys = np.concatenate([[0], cm, [1]])
+        ax.step(xs, ys, where="post", label=lbl, color=c, linewidth=2)
+    ax.axvline(prior[0], linestyle="--", color="gray", alpha=0.6, linewidth=2,
+               label="先验")
+    ax.set_xlabel(r"后验 $p(s_1 \mid x)$", fontsize=12)
+    ax.set_ylabel("累积概率", fontsize=12)
+    ax.text(0.03, 0.94, "CDF", transform=ax.transAxes, va="top")
+    ax.legend(fontsize=11)
+
+    ax2 = axes[1]
+    grid = np.linspace(0, 1, 200)
+
+    def integrated_cdf(sorted_vals, cum_mass, grid):
+        cdf = np.array([cum_mass[sorted_vals <= t].max()
+                        if np.any(sorted_vals <= t) else 0.0
+                        for t in grid])
+        return np.cumsum(cdf) * (grid[1] - grid[0])
+
+    int_μ = integrated_cdf(sv_μ, cm_μ, grid)
+    int_ν = integrated_cdf(sv_ν, cm_ν, grid)
+
+    ax2.plot(grid, int_μ, label=r"$\int F_\mu$", color="steelblue", linewidth=2)
+    ax2.plot(grid, int_ν, color="darkorange",
+             label=r"$\int F_\nu$", linewidth=2)
+    ax2.fill_between(grid, int_ν, int_μ,
+                     where=int_μ >= int_ν,
+                     alpha=0.2, color="steelblue",
+                     label=(r"$\int F_\mu \geq \int F_\nu$"
+                            r" （$\mu$ 是 $\nu$ 的 MPS）"))
+    ax2.set_xlabel(r"$t$", fontsize=12)
+    ax2.set_ylabel("积分 CDF", fontsize=12)
+    ax2.text(0.03, 0.94, "积分 CDF", transform=ax2.transAxes, va="top")
+    ax2.legend(fontsize=10)
+
+    plt.tight_layout()
+    plt.show()
+
+plot_sosd_posteriors(μ_info, ν_info, prior)
+```
+
+## 应用 1：产品质量信息
+
+{cite:t}`kihlstrom1974a` 将布莱克韦尔定理应用于消费者对产品质量信息的需求。
+
+- 未知状态 $\tilde{s}$ 是一个产品参数 $\theta$ 。
+- 消费者可以以成本 $c(\lambda)$ 购买 $\lambda$ 单位的信息。
+- 随着 $\lambda$ 上升，实验在布莱克韦尔意义下变得更具信息量。
+
+布莱克韦尔序表明，在不考虑成本的情况下，对每个期望效用最大化者来说，更多的信息总是更好的。
+
+在考虑成本时，消费者选择质量投资 $\theta$ 以最大化 *净价值*。
+
+如果质量投资以递减的收益转化为实验精度——比如，对某个速率参数 $a$ ，精度为 $\phi(\theta) = 1 - e^{-a\theta}$ ——那么信息的边际价值最终会随 $\theta$ 递减。
+
+在凸成本 $c(\theta) = c \, \theta^2$ 下，递增的边际成本最终会超越递减的边际价值，从而产生一个内部最优。
+
+```{code-cell} ipython3
+---
+mystnb:
+  figure:
+    caption: 具有二次成本的信息需求
+    name: fig-blackwell-information-demand
+---
+def gross_value(θ, prior2, U=entropy, rate=2):
+    """质量投资 θ 的总价值（收益递减）。"""
+    accuracy = 1 - np.exp(-rate * θ)
+    μ_t = (1 - accuracy) * np.ones((2, 2)) / 2 + accuracy * np.eye(2)
+    return degroot_value(μ_t, prior2, U)
+
+
+θ_fine = np.linspace(0, 1, 200)
+c = 0.6
+
+gross_vals = np.array([gross_value(θ, prior2) for θ in θ_fine])
+cost_vals = c * θ_fine**2
+net_vals = gross_vals - cost_vals
+marginal_vals = np.gradient(gross_vals, θ_fine)
+marginal_cost = 2 * c * θ_fine
+opt_idx = int(np.argmax(net_vals))
+
+fig, axes = plt.subplots(1, 2, figsize=(12, 4))
+
+ax = axes[0]
+ax.plot(θ_fine, gross_vals,
+        label="总价值 I(θ)",
+        color="steelblue", linewidth=2)
+ax.plot(θ_fine, cost_vals,
+        label=r"成本 $c\theta^2$",
+        color="tomato", linestyle="--", linewidth=2)
+ax.plot(θ_fine, net_vals,
+        label="净价值", color="green", linewidth=2)
+ax.axvline(θ_fine[opt_idx], color="green",
+           linestyle=":", linewidth=2,
+           label=f"θ* ≈ {θ_fine[opt_idx]:.2f}")
+ax.set_xlabel("质量投资 θ", fontsize=11)
+ax.set_ylabel("价值（熵单位）", fontsize=11)
+ax.legend(fontsize=10)
+
+ax2 = axes[1]
+ax2.plot(θ_fine, marginal_vals,
+         label="边际价值 I'(θ)",
+         color="steelblue", linewidth=2)
+ax2.plot(θ_fine, marginal_cost,
+         label=r"边际成本 $2c\theta$",
+         color="tomato", linestyle="--", linewidth=2)
+ax2.axvline(θ_fine[opt_idx], color="green",
+            linestyle=":", linewidth=2,
+            label=f"θ* ≈ {θ_fine[opt_idx]:.2f}")
+ax2.set_xlabel("质量投资 θ", fontsize=11)
+ax2.set_ylabel("边际价值 / 成本", fontsize=11)
+ax2.legend(fontsize=10)
+
+plt.tight_layout()
+plt.show()
+```
+
+最优投资 $\theta^*$ 出现在边际价值等于边际成本的地方。
+
+由于实验精度在 $\theta$ 上具有收益递减，投资的边际价值最终会降到上升的边际成本以下，从而产生一个真正的内部最优。
+
+提高 $c$ 会使边际成本曲线上移并减小 $\theta^*$ ，而更不对称的先验会使边际价值曲线移动并改变最优。
+
+## 应用 2：序贯实验设计
+
+{cite:t}`degroot1962` 将不确定性函数框架应用于 *序贯实验设计*。
+
+每一期一个统计学家观测一次抽取并更新后验。
+
+问题是哪一个实验序列最小化累积期望不确定性。
+
+如果一个实验在每一阶段都比另一个更具信息量，那么布莱克韦尔序倾向于在每一时期都使用更好的实验。
+
+我们现在为不同质量的实验模拟序贯信念更新。
+
+```{code-cell} ipython3
+---
+mystnb:
+  figure:
+    caption: 不同实验质量下的序贯后验路径
+    name: fig-blackwell-sequential-paths
+---
+def sequential_update(μ_matrix, prior, T=20, seed=0):
+    """在实验 μ 下模拟 T 次序贯信念更新。"""
+    rng = np.random.default_rng(seed)
+    N, M = μ_matrix.shape
+    beliefs = np.zeros((T + 1, N))
+    beliefs[0] = prior.copy()
+
+    true_state = rng.choice(N, p=prior)
+
+    for t in range(T):
+        p = beliefs[t]
+        signal = rng.choice(M, p=μ_matrix[true_state])
+        unnorm = μ_matrix[:, signal] * p
+        beliefs[t + 1] = unnorm / unnorm.sum()
+
+    return beliefs, true_state
+
+
+def plot_sequential_beliefs(θs_compare, prior2, T=25):
+    fig, axes = plt.subplots(1, len(θs_compare), figsize=(14, 4), sharey=True)
+
+    for ax, θ in zip(axes, θs_compare):
+        μ_t = make_experiment(θ, N=2)
+        for seed in range(15):
+            beliefs, ts = sequential_update(μ_t, prior2, T=T, seed=seed)
+            c = "steelblue" if ts == 0 else "darkorange"
+            ax.plot(beliefs[:, 0], alpha=0.35, color=c, linewidth=2)
+        ax.axhline(prior2[0], linestyle="--", color="gray", linewidth=2,
+                   label="先验")
+        ax.axhline(1.0, linestyle=":", color="steelblue", linewidth=2)
+        ax.axhline(0.0, linestyle=":", color="darkorange", linewidth=2)
+        ax.set_xlabel(r"时期 $t$", fontsize=11)
+        if θ == θs_compare[0]:
+            ax.set_ylabel(r"后验 $p(s_1 \mid x^t)$", fontsize=11)
+        ax.set_ylim(-0.05, 1.05)
+        ax.text(0.03, 0.94, f"θ = {θ}", transform=ax.transAxes, va="top")
+        ax.legend(fontsize=9)
+
+    plt.tight_layout()
+    plt.show()
+
+plot_sequential_beliefs([0.2, 0.5, 0.9], prior2, T=30)
+```
+
+更具信息量的实验使信念更快地收敛到真相。
+
+在正确的先验下，后验过程是一个鞅。
+
+```{code-cell} ipython3
+---
+mystnb:
+  figure:
+    caption: 后验鞅性质的无条件蕴含
+    name: fig-blackwell-martingale-mean
+---
+def check_martingale_mean(μ_matrix, prior, T=15, n_paths=2000, seed=0):
+    """
+    模拟许多信念路径并检验 E[p_t] = p_0。
+    """
+    rng = np.random.default_rng(seed)
+    N, M = μ_matrix.shape
+    all_paths = np.zeros((n_paths, T + 1, N))
+
+    for k in range(n_paths):
+        true_state = rng.choice(N, p=prior)
+        p = prior.copy()
+        all_paths[k, 0] = p
+        for t in range(T):
+            signal = rng.choice(M, p=μ_matrix[true_state])
+            unnorm = μ_matrix[:, signal] * p
+            p = unnorm / unnorm.sum()
+            all_paths[k, t + 1] = p
+
+    mean_path = all_paths[:, :, 0].mean(axis=0)
+
+    fig, ax = plt.subplots(figsize=(8, 4))
+    ax.plot(mean_path, color="steelblue", linewidth=2,
+            label=r"$\bar p_t(s_1)$（路径均值）")
+    ax.axhline(prior[0], linestyle="--", color="tomato", linewidth=2,
+               label=fr"先验 $p_0 = {prior[0]:.2f}$")
+    ax.set_xlabel(r"时期 $t$", fontsize=12)
+    ax.set_ylabel(r"$E[p_t(s_1)]$", fontsize=12)
+    ax.legend(fontsize=11)
+    ax.set_ylim(0, 1)
+    plt.tight_layout()
+    plt.show()
+
+    print(f"先验 = {prior[0]:.4f}")
+    print(f"各时期的平均信念均值：{mean_path.mean():.4f}")
+
+check_martingale_mean(μ_info, prior, T=20, n_paths=5000)
+```
+
+模拟的横截面均值在每一时期都保持接近先验。
+
+这是后验鞅性质的无条件蕴含。
+
+## 小结
+
+布莱克韦尔定理在统计实验上确定了一个 *偏序*，具有三个等价的刻画：
+
+| 标准 | 条件 |
+|-----------|-----------|
+| 经济学 | 每个决策者弱地偏好 $\mu$ 甚于 $\nu$ ： $B(\mu, A, u) \supseteq B(\nu, A, u)$ |
+| 充分性 | $\nu$ 是 $\mu$ 的混淆：对某个马尔可夫矩阵 $Q$ 有 $\nu = \mu Q$ |
+| 不确定性 | 对每个先验 $p$ 和每个凹函数 $U$ ， $\mu$ 更多地降低期望不确定性 |
+
+基尔斯特罗姆的贝叶斯阐述将 *后验分布* 置于中心。
+
+一个更具信息量的实验会生成一个更为分散、但均值与先验相同的后验分布。
+
+恰当的概率语言是后验信念单纯形上的凸序。
+
+在两状态情形下，这简化为 $[0, 1]$ 上熟悉的 SOSD / 积分 CDF 检验。
+
+德格鲁特的贡献在于将比较从特定效用函数扩展到全部凹不确定性函数类。
+
+
+## 数据处理不等式与粗粒化
+
+布莱克韦尔的条件——对某个马尔可夫核 $Q$ 有 $\nu = \mu Q$ ——与信息论、信息几何和机器学习中支撑 **数据处理不等式**（DPI）和 **粗粒化定理** 的数学操作是同一个。
+
+### f-散度的 DPI
+
+有限空间 $\Omega$ 上两个概率分布 $P$ 和 $Q$ 之间的 **f-散度** 为
+
+$$
+D_f(P \| Q) = \sum_{\omega \in \Omega} q_\omega \, f\!\left(\frac{p_\omega}{q_\omega}\right),
+$$
+
+其中 $f : (0,\infty) \to \mathbb{R}$ 是满足 $f(1) = 0$ 的凸函数。
+
+特例包括：
+
+| 散度 | 生成元 $f(t)$ |
+|:---|:---|
+| KL 散度 | $t \log t$ |
+| 平方 Hellinger $H^2$ | $(\sqrt{t} - 1)^2 / 2$ |
+| 全变差 TV | $\lvert t - 1 \rvert / 2$ |
+| 卡方 $\chi^2$ | $(t-1)^2$ |
+
+f-散度这一类别是由 {cite:t}`ali1966` 、 {cite:t}`csiszar1963` 和 {cite:t}`morimoto1963` 独立引入的；另见 {cite:t}`liese2012` 。
+
+```{prf:theorem} 数据处理不等式
+:label: thm-data-processing
+
+对任何 f-散度 $D_f$ 和任何马尔可夫核（随机变换）
+$\kappa$ ，以 $P \kappa$ 表示 $P$ 在 $\kappa$ 下的像，我们有
+
+$$
+D_f(P \| Q) \geq D_f(P\kappa \| Q\kappa).
+$$
+
+如果 $\kappa$ 由关于对 $\{P, Q\}$ 的充分统计量诱导，则等式成立。
+
+这种形式的逆命题需要额外的假设；下面给出一个清晰的二元模型刻画。
+```
+
+该证明来自将詹森不等式应用于凸函数 $f$ ，并利用 $\kappa$ 是随机矩阵这一事实 {cite}`csiszar1963` 。
+
+### 与布莱克韦尔充分性条件的联系
+
+在布莱克韦尔的框架中， $\mu$ 和 $\nu$ 是在同一状态空间 $S = \{s_1, \ldots, s_N\}$ 上的实验。
+
+对两个状态，每个实验有两行： $\mu_1 = \mu(s_1, \cdot)$ 和 $\mu_2 = \mu(s_2, \cdot)$ 。
+
+如果 $\nu = \mu Q$ （即 $\nu$ 是 $\mu$ 的混淆），那么对 $(\nu_1, \nu_2) = (\mu_1 Q, \mu_2 Q)$ 就是通过将马尔可夫核 $Q$ 应用于对 $(\mu_1, \mu_2)$ 得到的。
+
+粗粒化定理由此立即蕴含：
+
+$$
+D_f(\mu_1 \| \mu_2) \geq D_f(\nu_1 \| \nu_2)
+\quad \text{for every f-divergence } D_f,
+$$
+
+只要 $\mu \geq \nu$ 在布莱克韦尔序中成立。
+
+因此一个更具信息量的实验总是会产生 *更分离的* 条件信号分布，在每个 f-散度的意义下同时如此。
+
+由此，DPI 是关于状态 *可区分性* 的一个陈述：混淆一个实验会使得在每种统计可分性度量下，状态都更难被区分。
+
+对二元实验，等式条件将 DPI 直接联系回布莱克韦尔：对某个严格凸的 $f$ 有 $D_f(\mu_1 Q \| \mu_2 Q) = D_f(\mu_1 \| \mu_2)$ ，当且仅当 $Q$ 是关于 $(\mu_1, \mu_2)$ 的充分统计量。
+
+一旦充分性成立，则对每个凸函数 $f$ 等式都成立 {cite}`liese2012` 。
+
+### 信息几何：陈氏定理
+
+DPI 有一个无穷小的、微分几何的伴侣。
+
+**陈氏定理**  {cite}`chentsov1981` 断言， **Fisher 信息矩阵**  $I_F(\theta)$ 至多相差一个常数重缩放，是统计流形上在每个马尔可夫态射（粗粒化）下都收缩的 *唯一* 黎曼度量：
+
+$$
+I_F(\theta;\, \mu) \succeq I_F(\theta;\, \mu\kappa)
+\quad \text{for every differentiable family } \{\mu_\theta\} \text{ and every Markov kernel } \kappa.
+$$
+
+等式成立当且仅当 $\kappa$ 是关于 $\theta$ 的充分统计量。
+
+唯一性条款意义深远：它说 Fisher 信息不仅仅是碰巧在粗粒化下收缩的 *某一个* 度量，而是具有该性质的 *唯一一个* 度量。
+
+关于信息几何及其与充分性联系的详尽处理，参见 {cite:t}`amari_nagaoka2000` 。
+
+### 机器学习中的信息瓶颈
+
+{cite:t}`tishby_pereira_bialek1999` 的 **信息瓶颈** 方法提供了 DPI 在机器学习中一个突出的应用。
+
+给定输入 $X$ 和目标 $Y$ 上的联合分布 $p(X, Y)$ ，目标是找到一个由随机映射 $p(T \mid X)$ 形成的压缩表示 $T$ ，使其在用尽可能少的比特描述 $X$ 的同时，尽可能多地保留关于 $Y$ 的信息。
+
+该方法最小化拉格朗日量
+
+$$
+\mathcal{L}[p(T \mid X)] = I(X;\, T) - \beta \, I(T;\, Y),
+$$
+
+其中 $I(\cdot\,;\,\cdot)$ 表示互信息， $\beta \geq 0$ 支配压缩-相关性权衡。
+
+由于 $Y - X - T$ 构成一个马尔可夫链（T 仅从 X 导出），DPI 蕴含
+
+$$
+I(T;\, Y) \leq I(X;\, Y),
+$$
+
+等式成立当且仅当 $T$ 是给定 $X$ 时关于 $Y$ 的 **充分统计量**。
+
+布莱克韦尔序解释了为什么对 $X$ 的任何确定性或随机后处理都无法增加与 $Y$ 的互信息：应用于 $X$ 的任何马尔可夫核都是布莱克韦尔意义下的混淆，而 DPI 是粗粒化定理的互信息形式。
+
+用机器学习的语言来说，信息瓶颈在 $X$ 的所有混淆中搜索那个在压缩预算约束下最好地保留关于 $Y$ 相关信息的混淆。
+
+在一个具有输入 $X$ 、目标 $Y$ 以及层 $X \to T_1 \to T_2 \to \cdots \to T_L \to \hat{Y}$ 的深度神经网络中，每一层的表示都是前一层的混淆。
+
+于是 DPI 蕴含如下不等式链
+
+$$
+I(X;\, Y) \geq I(T_1;\, Y) \geq I(T_2;\, Y) \geq \cdots \geq I(T_L;\, Y),
+$$
+
+因此后继各层关于 $Y$ 的信息只会损失，绝不会增加。
+
+这一观察被 {cite}`shwartz_ziv_tishby2017` 置于研究深度网络所学内容的中心。
+
+{numref}`fig-blackwell-value-by-quality` 已经阐释了这一点：随着实验质量 $\theta$ 增加，每一种信息量度量都单调上升。
+
+DPI 反过来说的是同一件事：混淆（降低 $\theta$ ）只会收缩这些度量。
+
+### DPI-布莱克韦尔对应的小结
+
+下表汇集了布莱克韦尔框架与数据处理和粗粒化文献之间的精确对应。
+
+| 布莱克韦尔 / 德格鲁特 | 数据处理 / 粗粒化 |
+|:---|:---|
+| 混淆 $\nu = \mu Q$ | 将马尔可夫核 $\kappa$ 应用于对 $(P, Q) = (\mu_1, \mu_2)$ |
+| $\mu \geq \nu$ 在布莱克韦尔序中 | 对每个 f-散度 $D_f(\mu_1 \| \mu_2) \geq D_f(\nu_1 \| \nu_2)$ |
+| 充分性（ $Q$ 不丢弃任何东西） | DPI 中的等式；在二元模型中，一个严格凸的 $f$ 就已刻画充分性 |
+| 德格鲁特价值 $I(\mu; U_H)$ | 互信息 $I(\tilde{x}_\mu;\, \tilde{s})$ （香农 DPI） |
+| $\mu$ 与 $\nu$ 下的后验展开 | $\mu$ 下各行之间的 $D_f$ 更大 |
+| 布莱克韦尔定理（经济学 $\Leftrightarrow$ 混淆） | 对所有 $f$ 的 DPI $\Leftrightarrow$ 单个马尔可夫核见证占优 |
+| 陈氏唯一性定理 | Fisher 信息是唯一在粗粒化下收缩的度量 |
+| 信息瓶颈 $I(T;Y) \leq I(X;Y)$ | 应用于马尔可夫链 $Y{-}X{-}T$ 的互信息 DPI |
+
+
+## 与贝叶斯似然比学习的关系
+
+讲座 {doc}`likelihood_bayes` 是这里所发展框架的一个动态的两状态特例。
+
+设 $S = \{s_1, s_2\}$ ，其中 $s_1 \leftrightarrow f$ 且 $s_2 \leftrightarrow g$ ，其中 $f$ 和 $g$ 是两个候选的数据生成密度。
+
+那么单个观测是一个具有行 $f(\cdot)$ 和 $g(\cdot)$ 的布莱克韦尔实验，而历史 $w^t = (w_1, \ldots, w_t)$ 定义了一个更丰富的实验 $\mu_t$ 。
+
+由于总是可以丢弃最后 $t-s$ 个观测，对每个 $t > s$ ， $\mu_t$ 都布莱克韦尔占优 $\mu_s$ 。
+
+似然比过程
+
+$$
+L(w^t) = \prod_{i=1}^t \frac{f(w_i)}{g(w_i)}
+$$
+
+是 $\mu_t$ 的一个充分统计量，而后验
+
+$$
+\pi_t = \Pr(s_1 \mid w^t)
+= \frac{\pi_0 L(w^t)}{\pi_0 L(w^t) + 1 - \pi_0}
+$$
+
+是基尔斯特罗姆在这个两状态设定下的标准实验。
+
+它的鞅性质 $E[\pi_t] = \pi_0$ 正是上面为后验分布证明的均值保持结果。
+
+同样地， $\mu_t \geq \mu_s$ 意味着 $\pi_t$ 的分布是 $\pi_s$ 分布的一个均值保持展开，因此额外的数据会把信念推向离 $0$ 和 $1$ 更远的地方，同时在每个凹不确定性函数下降低期望不确定性。
+
+### 小结表
+
+下表在不重复前面论证的情况下记录了两个讲座之间的对照词典。
+
+| {doc}`likelihood_bayes` 中的概念 | 本讲座中的概念 |
+|---|---|
+| 状态 $\{f, g\}$ | 状态空间 $S = \{s_1, s_2\}$ |
+| 密度 $f(\cdot)$ 、 $g(\cdot)$ | 实验矩阵 $\mu$ 的各行 |
+| 单次抽取 $w_t$ | 具有连续信号空间的布莱克韦尔实验 |
+| $t$ 次 IID 抽取的历史 $w^t$ | 布莱克韦尔占优 $\mu_s$（ $s < t$ ）的更丰富实验 $\mu_t$ |
+| 似然比 $L(w^t)$ | $\mu_t$ 的充分统计量 |
+| 先验 $\pi_0$ | 1-单纯形 $[0,1]$ 上的先验 $p \in P$ |
+| 后验 $\pi_t$ | $P = [0,1]$ 上的后验（基尔斯特罗姆的标准实验） |
+| $\pi_t$ 在各历史上的分布 | $\hat{\mu}^c$ （基尔斯特罗姆的后验分布） |
+| 鞅性质 $E[\pi_t] = \pi_0$ | $\hat{\mu}^c$ 的均值保持 |
+| $\pi_t \to 0$ 或 $1$ 几乎必然 | 后验向顶点展开（极限中的 MPS） |
+| 互信息 $I(\mu_t; U_H)$ | 德格鲁特信息价值 |
+| 更多抽取 $\Rightarrow$ 对所有决策者更好 | 布莱克韦尔序 $\mu_t \geq \mu_s$ |
+| 混淆（丢弃最后 $t - s$ 次抽取） | 满足 $\mu_s = \mu_t Q$ 的随机变换 $Q$ |

--- a/lectures/chow_business_cycles.md
+++ b/lectures/chow_business_cycles.md
@@ -1,0 +1,1686 @@
+---
+jupytext:
+  text_representation:
+    extension: .md
+    format_name: myst
+    format_version: 0.13
+    jupytext_version: 1.17.1
+kernelspec:
+  display_name: Python 3 (ipykernel)
+  language: python
+  name: python3
+translation:
+  title: 加速原理与商业周期的本质
+  headings:
+    Overview: 概述
+    Empirical foundation for the acceleration principle: 加速原理的经验基础
+    'Empirical foundation for the acceleration principle::An example: automobile demand': 一个例子：汽车需求
+    Empirical foundation for the acceleration principle::From stock adjustment to acceleration: 从存量调整到加速
+    Acceleration enables oscillations: 加速使振荡成为可能
+    A linear system with shocks: 带冲击的线性系统
+    A linear system with shocks::Autocovariances in terms of eigenvalues: 用特征值表示的自协方差
+    A linear system with shocks::Complex roots and damped oscillations: 复根与阻尼振荡
+    From autocovariances to spectra: 从自协方差到谱
+    Spectral peaks in the Hansen-Samuelson model: Hansen-Samuelson 模型中的谱峰
+    Spectral peaks in the Hansen-Samuelson model::The model as a first-order system: 作为一阶系统的模型
+    Spectral peaks in the Hansen-Samuelson model::The spectral density formula: 谱密度公式
+    Spectral peaks in the Hansen-Samuelson model::Conditions for a spectral peak: 谱峰的条件
+    Spectral peaks in the Hansen-Samuelson model::Real positive roots cannot produce peaks: 实正根无法产生峰值
+    Real roots can produce peaks in general models: 实根可以在一般模型中产生峰值
+    Real roots can produce peaks in general models::Example: 例子
+    Real roots can produce peaks in general models::The Slutsky connection: 斯卢茨基联系
+    Real roots can produce peaks in general models::The general lesson: 一般教训
+    A calibrated model in the frequency domain: 频域中的一个校准模型
+    A calibrated model in the frequency domain::The cycle subsystem: 周期子系统
+    A calibrated model in the frequency domain::Reconstructing $A$ and computing $F(\omega)$: 重构 $A$ 并计算 $F(\omega)$
+    A calibrated model in the frequency domain::Canonical coordinates: 规范坐标
+    A calibrated model in the frequency domain::How variables move together across frequencies: 变量如何跨频率一起运动
+    A calibrated model in the frequency domain::Lead-lag relationships: 领先-滞后关系
+    A calibrated model in the frequency domain::Building blocks of spectral shape: 谱形状的组成部分
+    Summary: 总结
+    Exercises: 练习
+---
+
+(chow_business_cycles)=
+
+```{raw} jupyter
+<div id="qe-notebook-header" align="right" style="text-align:right;">
+        <a href="https://quantecon.org/" title="quantecon.org">
+                <img style="width:250px;display:inline;" width="250px" src="https://assets.quantecon.org/img/qe-menubar-logo.svg" alt="QuantEcon">
+        </a>
+</div>
+```
+
+# 加速原理与商业周期的本质
+
+```{contents} Contents
+:depth: 2
+```
+
+## 概述
+
+本讲座研究 Gregory Chow 的两篇经典论文：
+
+- {cite:t}`Chow1968` 提出了加速原理的经验证据，描述了加速如何促进振荡，并分析了受随机冲击影响的线性差分方程中谱峰出现的条件
+- {cite:t}`ChowLevitan1969` 提出了对一个校准的美国宏观计量经济模型的谱分析，并讲授了谱增益、相干性和领先-滞后模式
+
+这些论文与以下讲座中的思想相关：
+
+- {doc}`samuelson` 中的乘数-加速数机制
+- {doc}`linear_models` 中的线性随机差分方程和自协方差
+- {doc}`var_dmd` 中的多元动态特征模态
+- {doc}`eig_circulant` 中的傅里叶思想（以及关于经验估计的进阶讲座 {doc}`advanced:estspec`）
+
+{cite:t}`Chow1968` 建立在早期在美国投资数据上检验加速原理的经验工作之上。
+
+在建立理论框架之前，我们先从这些经验证据开始。
+
+我们将不断回到三个思想：
+
+- 在确定性模型中，振荡表明转移矩阵存在复特征值。
+- 在随机模型中，"周期"表现为（单变量）谱密度中的局部峰值。
+- 谱峰依赖于特征值，但也依赖于冲击如何进入系统以及可观测量如何加载于特征模态。
+
+让我们从一些标准导入开始：
+
+```{code-cell} ipython3
+import numpy as np
+import matplotlib.pyplot as plt
+import matplotlib as mpl  # i18n
+FONTPATH = "fonts/SourceHanSerifSC-SemiBold.otf"  # i18n
+mpl.font_manager.fontManager.addfont(FONTPATH)  # i18n
+mpl.rcParams['font.family'] = ['Source Han Serif SC']  # i18n
+```
+
+我们将在整个讲座中使用以下辅助函数
+
+```{code-cell} ipython3
+def spectral_density_var1(A, V, ω_grid):
+    """VAR(1) 的谱密度矩阵：y_t = A y_{t-1} + u_t。"""
+    A, V = np.asarray(A), np.asarray(V)
+    n = A.shape[0]
+    I = np.eye(n)
+    F = np.empty((len(ω_grid), n, n), dtype=complex)
+    for k, ω in enumerate(ω_grid):
+        H = np.linalg.inv(I - np.exp(-1j * ω) * A)
+        F[k] = (H @ V @ H.conj().T) / (2 * np.pi)
+    return F
+
+def spectrum_of_linear_combination(F, b):
+    """给定谱矩阵 F(ω)，计算 x_t = b'y_t 的谱。"""
+    b = np.asarray(b).reshape(-1, 1)
+    return np.array([np.real((b.T @ F[k] @ b).item()) 
+                                for k in range(F.shape[0])])
+
+def simulate_var1(A, V, T, burn=200, seed=1234):
+    r"""模拟 y_t = A y_{t-1} + u_t，其中 u_t \sim N(0, V)。"""
+    rng = np.random.default_rng(seed)
+    A, V = np.asarray(A), np.asarray(V)
+    n = A.shape[0]
+    chol = np.linalg.cholesky(V)
+    y = np.zeros((T + burn, n))
+
+    for t in range(1, T + burn):
+        y[t] = A @ y[t - 1] + chol @ rng.standard_normal(n)
+
+    return y[burn:]
+
+def sample_autocorrelation(x, max_lag):
+    """从滞后 0 到 max_lag 计算一维数组的样本自相关。"""
+    x = np.asarray(x)
+    x = x - x.mean()
+    denom = np.dot(x, x)
+    acf = np.empty(max_lag + 1)
+    for k in range(max_lag + 1):
+        acf[k] = np.dot(x[:-k] if k else x, x[k:]) / denom
+    return acf
+```
+
+(empirical_section)=
+## 加速原理的经验基础
+
+{cite:t}`Chow1968` 一开始回顾了来自早期宏观计量经济工作的加速原理的经验证据。
+
+Chow 使用 1931--40 年和 1948--63 年的年度观测数据，在三个投资类别上检验了加速方程：
+
+- 新建筑
+- 生产者耐用设备的私人国内总投资加上企业库存变化
+- 上述后两个变量分别考虑
+
+在每种情况下，当回归同时包含 $Y_t$ 和 $Y_{t-1}$（其中 $Y$ 是国民生产总值减去净转移支付后的税收）时，$Y_{t-1}$ 上的系数与 $Y_t$ 上的系数*符号相反*，且绝对值略小。
+
+等价地，当用 $\Delta Y_t$ 和 $Y_{t-1}$ 表示时，$Y_{t-1}$ 上的系数是 $\Delta Y_t$ 系数的一个很小的比例。
+
+### 一个例子：汽车需求
+
+Chow 用他早期关于汽车需求工作中的汽车净投资数据给出了一个清晰的说明。
+
+使用 1922--41 年和 1948--57 年的年度数据，他通过最小二乘法估计：
+
+```{math}
+:label: chow_auto_eq5
+
+y_t^n = \underset{(0.0022)}{0.0155} Y_t \underset{(0.0020)}{- 0.0144} Y_{t-1} \underset{(0.0056)}{- 0.0239} p_t \underset{(0.0040)}{+ 0.0199} p_{t-1} + \underset{(0.101)}{0.351} y_{t-1}^n + \text{const.}
+```
+
+其中：
+- $Y_t$ 是人均实际可支配个人收入
+- $p_t$ 是汽车的相对价格指数
+- $y_t^n$ 是人均客车净投资
+- 括号中为标准误
+
+关键观察：$Y_{t-1}$ 和 $p_{t-1}$ 上的系数是 $Y_t$ 和 $p_t$ 系数的*相反数*。
+
+这种模式正是加速原理所预测的。
+
+### 从存量调整到加速
+
+一旦我们接受资本的存量调整需求方程，对加速的经验支持就不足为奇了：
+
+```{math}
+:label: chow_stock_adj_emp
+
+s_{it} = a_i Y_t + b_i s_{i,t-1}
+```
+
+其中 $s_{it}$ 是资本品 $i$ 的存量。
+
+加速方程 {eq}`chow_auto_eq5` 本质上是 {eq}`chow_stock_adj_emp` 的*一阶差分*。
+
+净投资是存量的变化，$y_{it}^n = \Delta s_{it}$，对 {eq}`chow_stock_adj_emp` 作差分得到：
+
+```{math}
+:label: chow_acc_from_stock
+
+y_{it}^n = a_i \Delta Y_t + b_i y_{i,t-1}^n
+```
+
+在水平形式中，$Y_t$ 和 $Y_{t-1}$ 上的系数分别为 $a_i$ 和 $-a_i(1-b_i)$。
+
+当 $b_i$ 离 1 不太远时，它们符号相反且大小相近。
+
+存量调整与加速之间的这种联系是 Chow 关于为什么加速对商业周期至关重要论证的核心。
+
+## 加速使振荡成为可能
+
+在建立了加速的经验证据之后，我们现在考察为什么它在理论上对产生振荡至关重要。
+
+{cite:t}`Chow1968` 提出了一个基本问题：如果我们仅使用带有简单分布滞后的标准需求方程构建一个宏观模型，系统能否产生持续的振荡？
+
+他证明了，在自然的符号约束下，答案是否定的。
+
+耐用品的存量调整需求导致投资方程中 $Y_{t-1}$ 上的系数为负。
+
+这个负系数刻画了**加速效应**：投资不仅对收入水平作出反应，还对其变化率作出反应。
+
+这个负系数也是使特征方程中出现复根成为可能的原因。
+
+没有它，Chow 证明了只有正系数的需求系统具有实正根，因此没有振荡动态。
+
+{doc}`samuelson` 讲座通过 Hansen-Samuelson 乘数-加速数模型详细探讨了这一机制。
+
+这里我们简要说明这个效应。
+
+取乘数-加速数运动定律：
+
+```{math}
+Y_t = c Y_{t-1} + v (Y_{t-1} - Y_{t-2}),
+```
+
+并将其重写为 $(Y_t, Y_{t-1})$ 中的一阶系统。
+
+```{code-cell} ipython3
+def samuelson_transition(c, v):
+    return np.array([[c + v, -v], [1.0, 0.0]])
+
+# 比较弱加速与强加速
+# 弱：c=0.8, v=0.1 给出实根（判别式 > 0）
+# 强：c=0.6, v=0.8 给出复根（判别式 < 0）
+cases = [("弱加速", 0.8, 0.1),
+         ("强加速", 0.6, 0.8)]
+A_list = [samuelson_transition(c, v) for _, c, v in cases]
+
+for (label, c, v), A in zip(cases, A_list):
+    eig = np.linalg.eigvals(A)
+    disc = (c + v)**2 - 4*v
+    print(
+        f"{label}: c={c}, v={v}, 判别式={disc:.2f}, 特征值={eig}")
+```
+
+在弱加速（$v=0.1$）下，判别式为正，根为实数。
+
+在强加速（$v=0.8$）下，判别式为负，根是共轭复数，从而使振荡动态成为可能。
+
+现在让我们看看这些不同的特征值结构如何影响对 $Y$ 中一次性冲击的脉冲响应
+
+```{code-cell} ipython3
+T = 40
+s0 = np.array([1.0, 0.0])
+irfs = []
+for A in A_list:
+    s = s0.copy()
+    path = np.empty(T + 1)
+    for t in range(T + 1):
+        path[t] = s[0]
+        s = A @ s
+    irfs.append(path)
+
+fig, ax = plt.subplots(figsize=(10, 4))
+ax.plot(range(T + 1), irfs[0], lw=2,
+                label="弱加速（实根）")
+ax.plot(range(T + 1), irfs[1], lw=2,
+                label="强加速（复根）")
+ax.axhline(0.0, lw=0.8, color='gray')
+ax.set_xlabel("时间")
+ax.set_ylabel(r"$Y_t$")
+ax.legend(frameon=False)
+plt.tight_layout()
+plt.show()
+```
+
+在弱加速下，脉冲响应单调衰减。
+
+在强加速下，它振荡。
+
+我们可以问，随着加速数 $v$ 的增加，特征值如何变化。
+
+随着我们增加加速数 $v$，特征值离原点越来越远。
+
+对于这个模型，特征值的模是 $|\lambda| = \sqrt{v}$，所以稳定性边界是 $v = 1$。
+
+```{code-cell} ipython3
+v_grid = [0.2, 0.4, 0.6, 0.8, 0.95]
+c = 0.6
+T_irf = 40  # 脉冲响应的周期数
+
+fig, axes = plt.subplots(1, 2, figsize=(12, 5))
+
+for v in v_grid:
+    A = samuelson_transition(c, v)
+    eig = np.linalg.eigvals(A)
+
+    # 特征值（左图）
+    axes[0].scatter(eig.real, eig.imag, s=40, label=f'$v={v}$')
+
+    # 脉冲响应（右图）
+    s = np.array([1.0, 0.0])
+    irf = np.empty(T_irf + 1)
+    for t in range(T_irf + 1):
+        irf[t] = s[0]
+        s = A @ s
+    axes[1].plot(range(T_irf + 1), irf, lw=2, label=f'$v={v}$')
+
+# 可视化特征值位置和单位圆
+θ_circle = np.linspace(0, 2*np.pi, 100)
+axes[0].plot(np.cos(θ_circle), np.sin(θ_circle),
+                'k--', lw=0.8, label='单位圆')
+axes[0].set_xlabel('实部')
+axes[0].set_ylabel('虚部')
+axes[0].set_aspect('equal')
+axes[0].legend(frameon=False)
+
+# 脉冲响应面板
+axes[1].axhline(0, lw=0.8, color='gray')
+axes[1].set_xlabel('时间')
+axes[1].set_ylabel(r'$Y_t$')
+axes[1].legend(frameon=False)
+
+plt.tight_layout()
+plt.show()
+```
+
+随着 $v$ 增加，特征值接近单位圆，振荡变得更加持久。
+
+这说明加速创造了复特征值，而复特征值是确定性系统中振荡动态所必需的。
+
+但当我们加入随机冲击时会发生什么？
+
+拉格纳·弗里希 {cite}`frisch33` 的一个洞见是，当系统被随机扰动持续扰动时，阻尼振荡可以被"维持"。
+
+为了正式研究这一点，我们需要引入随机框架。
+
+## 带冲击的线性系统
+
+我们分析一个一阶线性随机系统
+
+```{math}
+:label: chow_var1
+
+y_t = A y_{t-1} + u_t,
+\qquad
+\mathbb E[u_t] = 0,
+\qquad
+\mathbb E[u_t u_t^\top] = V,
+\qquad
+\mathbb E[u_t u_{t-k}^\top] = 0, \quad k \neq 0.
+```
+
+当 $A$ 的特征值严格位于单位圆内时，该过程是协方差平稳的，其自协方差存在。
+
+用 {doc}`linear_models` 的记号，这与保证离散李雅普诺夫方程有唯一解的稳定性条件相同。
+
+定义滞后-$k$ 自协方差矩阵
+
+```{math}
+:label: chow_autocov_def
+
+\Gamma_k := \mathbb E[y_t y_{t-k}^\top] .
+```
+
+标准计算（也在 {cite}`Chow1968` 中推导）给出递归
+
+```{math}
+:label: chow_autocov_rec
+
+\Gamma_k = A \Gamma_{k-1}, \quad k \ge 1,
+\qquad\text{and}\qquad
+\Gamma_0 = A \Gamma_0 A^\top + V.
+```
+
+第二个方程是 $\Gamma_0$ 的离散李雅普诺夫方程。
+
+{cite:t}`Chow1968` 用拉格纳·弗里希的一段话来引出随机分析：
+
+> 我们讨论过的例子……表明，当一个[确定性的]经济系统产生振荡时，这些振荡最常见的是有阻尼的。
+> 但在现实中，周期……通常不是有阻尼的。
+> 如何解释摆动的维持？
+> ……我认为一种特别富有成效和有前途的方法是研究，如果一个确定性动态系统的解暴露于一系列不规则冲击之下，它会变成什么样……
+> 因此，通过将两个思想联系起来：(1) 确定性动态系统的连续解，以及 (2) 介入并提供可能维持摆动能量的间断冲击——我们得到了一个理论设定，它似乎为那些我们习惯于在统计时间数据中看到的运动提供了一个理性的解释。
+>
+> -- 拉格纳·弗里希 (1933) {cite}`frisch33`
+
+Chow 的主要洞见是，确定性系统中的振荡对于在随机系统中产生"周期"*既不必要也不充分*。
+
+我们必须把随机因素纳入考虑。
+
+我们将证明，即使特征值是实数（没有确定性振荡），随机系统也能在其自协方差和谱密度中表现出周期性模式。
+
+### 用特征值表示的自协方差
+
+设 $\lambda_1, \ldots, \lambda_p$ 是 $A$ 的不同的、可能为复数的特征值，设 $B$ 是以对应右特征向量为列的矩阵：
+
+```{math}
+:label: chow_eigen_decomp
+
+A B = B D_\lambda, \quad \text{或等价地} \quad A = B D_\lambda B^{-1}
+```
+
+其中 $D_\lambda = \text{diag}(\lambda_1, \ldots, \lambda_p)$。
+
+定义规范变量 $z_t = B^{-1} y_t$。
+
+它们满足解耦动态：
+
+```{math}
+:label: chow_canonical_dynamics
+
+z_t = D_\lambda z_{t-1} + \varepsilon_t
+```
+
+其中 $\varepsilon_t = B^{-1} u_t$ 具有协方差矩阵 $W = B^{-1} V (B^{-1})^\top$。
+
+规范变量的自协方差矩阵，记为 $\Gamma_k^*$，满足
+
+```{math}
+:label: chow_canonical_autocov
+
+\Gamma_k^* = D_\lambda^k \Gamma_0^*, \quad k = 1, 2, 3, \ldots
+```
+
+以及
+
+```{math}
+:label: chow_gamma0_star
+
+\Gamma_0^* = \left( \frac{w_{ij}}{1 - \lambda_i \lambda_j} \right)
+```
+
+其中 $w_{ij}$ 是 $W$ 的元素。
+
+原始变量的自协方差矩阵为
+
+```{math}
+:label: chow_autocov_eigen
+
+\Gamma_k = B \Gamma_k^* B^\top = B D_\lambda^k \Gamma_0^* B^\top, \quad k = 0, 1, 2, \ldots
+```
+
+标量自协方差 $\gamma_{ij,k} = \mathbb{E}[y_{it} y_{j,t-k}]$ 是特征值幂的*线性组合*：
+
+```{math}
+:label: chow_scalar_autocov
+
+\gamma_{ij,k} = \sum_m \sum_n b_{im} b_{jn} \gamma^*_{mn,0} \lambda_m^k = \sum_m d_{ij,m} \lambda_m^k
+```
+
+将此与来自初始条件 $y_0$ 的确定性时间路径进行比较：
+
+```{math}
+:label: chow_det_path
+
+y_{it} = \sum_j b_{ij} z_{j0} \lambda_j^t
+```
+
+自协方差函数 {eq}`chow_scalar_autocov` 和确定性路径 {eq}`chow_det_path` 都是 $\lambda_m^k$（或 $\lambda_j^t$）的线性组合。
+
+### 复根与阻尼振荡
+
+当特征值以共轭复数对 $\lambda = r e^{\pm i\theta}$（$r < 1$）出现时，它们对自协方差函数的贡献是一个**阻尼余弦**：
+
+```{math}
+:label: chow_damped_cosine
+
+2 s r^k \cos(\theta k + \phi)
+```
+
+其中适当的幅度 $s$ 和相位 $\phi$ 由特征向量载荷决定。
+
+在确定性模型中，这种复根产生阻尼振荡时间路径。
+
+在随机模型中，它们产生阻尼振荡自协方差函数。
+
+正是在这个意义上，确定性振荡可以在随机模型中被"维持",但正如我们将看到的，特征值与谱峰之间的联系比这暗示的更为微妙。
+
+## 从自协方差到谱
+
+Chow 的关键步骤是将自协方差序列 $\{\Gamma_k\}$ 转换为一个频域对象。
+
+**谱密度矩阵**是 $\Gamma_k$ 的傅里叶变换：
+
+```{math}
+:label: chow_spectral_def
+
+F(\omega) := \frac{1}{2\pi} \sum_{k=-\infty}^{\infty} \Gamma_k e^{-i \omega k},
+\qquad \omega \in [0, \pi].
+```
+
+对于 VAR(1) 系统 {eq}`chow_var1`，这个和有一个闭式
+
+```{math}
+:label: chow_spectral_closed
+
+F(\omega)
+= \frac{1}{2\pi}
+\left(I - A e^{-i\omega}\right)^{-1}
+V
+\left(I - A^\top e^{i\omega}\right)^{-1}.
+```
+
+$F(\omega)$ 告诉我们 $y_t$ 中有多少变化与（角）频率 $\omega$ 的周期相关联。
+
+较高的频率对应于快速振荡，即每单位时间内序列完成许多上下运动的短周期。
+
+较低的频率对应于较慢的振荡，即在延长的时间段内展开的长周期。
+
+对应的周期长度（或周期）为
+
+```{math}
+:label: chow_period
+
+T(\omega) = \frac{2\pi}{\omega}.
+```
+
+因此，频率 $\omega = \pi$ 对应于 $T = 2$ 个周期的最短可能周期，而接近零的频率对应于非常长的周期。
+
+当谱密度 $F(\omega)$ 集中在特定频率时，它表明时间序列在这些频率上表现出显著的周期性行为。
+
+进阶讲座 {doc}`advanced:estspec` 解释了如何从数据估计 $F(\omega)$。
+
+这里我们关注模型隐含的谱。
+
+我们前面看到加速创造了复特征值，这使得振荡脉冲响应成为可能。
+
+但复根能保证谱峰吗？
+
+它们对谱峰是必要的吗？
+
+Chow 为 Hansen-Samuelson 模型提供了精确的答案。
+
+## Hansen-Samuelson 模型中的谱峰
+
+{cite:t}`Chow1968` 提供了 Hansen-Samuelson 乘数-加速数模型的详细谱分析，推导了谱峰出现的精确条件。
+
+该分析揭示，在这个特定模型中，复根对峰值是*必要的*，但正如我们稍后将看到的，这在一般情况下并不成立。
+
+### 作为一阶系统的模型
+
+二阶 Hansen-Samuelson 方程可以写成一阶系统：
+
+```{math}
+:label: chow_hs_system
+
+\begin{bmatrix} y_{1t} \\ y_{2t} \end{bmatrix} =
+\begin{bmatrix} a_{11} & a_{12} \\ 1 & 0 \end{bmatrix}
+\begin{bmatrix} y_{1,t-1} \\ y_{2,t-1} \end{bmatrix} +
+\begin{bmatrix} u_{1t} \\ 0 \end{bmatrix}
+```
+
+其中 $y_{2t} = y_{1,t-1}$ 只是 $y_{1t}$ 的滞后值。
+
+这种结构隐含了自协方差之间的一个特殊关系：
+
+```{math}
+:label: chow_hs_autocov_relation
+
+\gamma_{11,k} = \gamma_{22,k} = \gamma_{12,k-1} = \gamma_{21,k+1}
+```
+
+使用自协方差递归，Chow 证明这导致条件
+
+```{math}
+:label: chow_hs_condition53
+
+\gamma_{11,-1} = d_{11,1} \lambda_1^{-1} + d_{11,2} \lambda_2^{-1} = \gamma_{11,1} = d_{11,1} \lambda_1 + d_{11,2} \lambda_2
+```
+
+它以一种有用的方式约束了谱密度。
+
+### 谱密度公式
+
+从方程 {eq}`chow_scalar_autocov` 和标量核 $g_i(\omega) = (1 - \lambda_i^2)/(1 + \lambda_i^2 - 2\lambda_i \cos\omega)$，$y_{1t}$ 的谱密度为：
+
+```{math}
+:label: chow_hs_spectral
+
+f_{11}(\omega) = d_{11,1} g_1(\omega) + d_{11,2} g_2(\omega)
+```
+
+它可以写成组合形式：
+
+```{math}
+:label: chow_hs_spectral_combined
+
+f_{11}(\omega) = \frac{d_{11,1}(1 - \lambda_1^2)(1 + \lambda_2^2) + d_{11,2}(1 - \lambda_2^2)(1 + \lambda_1^2) - 2[d_{11,1}(1-\lambda_1^2)\lambda_2 + d_{11,2}(1-\lambda_2^2)\lambda_1]\cos\omega}{(1 + \lambda_1^2 - 2\lambda_1 \cos\omega)(1 + \lambda_2^2 - 2\lambda_2 \cos\omega)}
+```
+
+一个关键观察：由于条件 {eq}`chow_hs_condition53`，*分子不是 $\cos\omega$ 的函数*。
+
+因此，要找到 $f_{11}(\omega)$ 的最大值，我们只需找到分母的最小值。
+
+### 谱峰的条件
+
+分母关于 $\omega$ 的一阶导数为：
+
+```{math}
+:label: chow_hs_derivative
+
+2[(1 + \lambda_1^2)\lambda_2 + (1 + \lambda_2^2)\lambda_1] \sin\omega - 8\lambda_1 \lambda_2 \cos\omega \sin\omega
+```
+
+对于 $0 < \omega < \pi$，我们有 $\sin\omega > 0$，所以导数为零当且仅当：
+
+```{math}
+:label: chow_hs_foc
+
+(1 + \lambda_1^2)\lambda_2 + (1 + \lambda_2^2)\lambda_1 = 4\lambda_1 \lambda_2 \cos\omega
+```
+
+对于*共轭复根* $\lambda_1 = r e^{i\theta}$、$\lambda_2 = r e^{-i\theta}$，代入 {eq}`chow_hs_foc` 得到：
+
+```{math}
+:label: chow_hs_peak_condition
+
+\cos\omega = \frac{1 + r^2}{2r} \cos\theta
+```
+
+二阶导数确认当 $\omega < \frac{3\pi}{4}$ 时这是一个最大值。
+
+有效解的必要条件是：
+
+```{math}
+:label: chow_hs_necessary
+
+-1 < \frac{1 + r^2}{2r} \cos\theta < 1
+```
+
+我们可以将其解释为：
+- 当 $r \approx 1$ 时，因子 $(1+r^2)/2r \approx 1$，所以 $\omega \approx \theta$
+- 当 $r$ 较小（例如 0.3 或 0.4）时，条件 {eq}`chow_hs_necessary` 只有在 $\cos\theta \approx 0$ 时才能满足，这意味着 $\theta \approx \pi/2$（约 4 个周期的周期）
+
+如果 $\theta = 54^\circ$（对应于 6.67 个周期的周期）且 $r = 0.4$，那么 $(1+r^2)/2r = 1.45$，给出 $\cos\omega = 1.45 \times 0.588 = 0.85$，即 $\omega = 31.5^\circ$，对应于 11.4 个周期的周期，这比确定性周期长得多。
+
+```{code-cell} ipython3
+def peak_condition_factor(r):
+    """计算 (1 + r^2) / (2r)"""
+    return (1 + r**2) / (2 * r)
+
+θ_deg = 54
+θ = np.deg2rad(θ_deg)
+r_grid = np.linspace(0.3, 0.99, 100)
+
+# 对每个 r，计算隐含的峰值频率
+ω_peak = []
+for r in r_grid:
+    factor = peak_condition_factor(r)
+    cos_ω = factor * np.cos(θ)
+    if -1 < cos_ω < 1:
+        ω_peak.append(np.arccos(cos_ω))
+    else:
+        ω_peak.append(np.nan)
+
+ω_peak = np.array(ω_peak)
+period_peak = 2 * np.pi / ω_peak
+
+fig, axes = plt.subplots(1, 2, figsize=(12, 4))
+
+axes[0].plot(r_grid, np.rad2deg(ω_peak), lw=2)
+axes[0].axhline(θ_deg, ls='--', lw=1.0, color='gray', 
+        label=rf'$\theta = {θ_deg}°$')
+axes[0].set_xlabel('特征值模 $r$')
+axes[0].set_ylabel(r'峰值频率 $\omega$（度）')
+axes[0].legend(frameon=False)
+
+axes[1].plot(r_grid, period_peak, lw=2)
+axes[1].axhline(360/θ_deg, ls='--', lw=1.0, color='gray', 
+        label=rf'确定性周期 = {360/θ_deg:.1f}')
+axes[1].set_xlabel('特征值模 $r$')
+axes[1].set_ylabel('峰值周期')
+axes[1].legend(frameon=False)
+
+plt.tight_layout()
+plt.show()
+
+r_example = 0.4
+factor = peak_condition_factor(r_example)
+cos_ω = factor * np.cos(θ)
+ω_example = np.arccos(cos_ω)
+print(f"Chow 的例子：r = {r_example}, θ = {θ_deg}°")
+print(f"  cos(ω) = {cos_ω:.3f}")
+print(f"  ω = {np.rad2deg(ω_example):.1f}°")
+print(f"  峰值周期 = {360/np.rad2deg(ω_example):.1f}")
+```
+
+当 $r \to 1$ 时，峰值频率收敛到 $\theta$。
+
+对于较小的 $r$，峰值频率可能与确定性振荡频率有很大不同。
+
+### 实正根无法产生峰值
+
+对于*实正根* $\lambda_1, \lambda_2 > 0$，一阶条件 {eq}`chow_hs_foc` 无法满足。
+
+要理解为什么，回顾在内部频率 $\omega \in (0, \pi)$ 处的谱峰需要
+
+```{math}
+\cos\omega = \frac{(1 + \lambda_1^2)\lambda_2 + (1 + \lambda_2^2)\lambda_1}{4\lambda_1 \lambda_2}.
+```
+
+为使其有解，我们需要右边位于 $[-1, 1]$ 内。
+
+但对于正的 $\lambda_1, \lambda_2$，分子超过 $4\lambda_1\lambda_2$：
+
+```{math}
+:label: chow_hs_real_proof
+
+(1 + \lambda_1^2)\lambda_2 + (1 + \lambda_2^2)\lambda_1 - 4\lambda_1\lambda_2 = \lambda_1(1-\lambda_2)^2 + \lambda_2(1-\lambda_1)^2.
+```
+
+右边是两个非负项之和（每一项都是一个正数乘以一个平方）。
+
+它只有在 $\lambda_1 = 1$ 和 $\lambda_2 = 1$ 同时成立时才等于零，这违反了稳定性条件 $|\lambda_i| < 1$。
+
+对于任何具有实正根的稳定系统，这个表达式严格为正，所以
+
+```{math}
+:label: chow_hs_real_impossible
+
+\cos\omega = \frac{(1 + \lambda_1^2)\lambda_2 + (1 + \lambda_2^2)\lambda_1}{4\lambda_1 \lambda_2} > 1,
+```
+
+这是不可能的。
+
+这是一个关键结果：在 Hansen-Samuelson 模型中，*复根对于内部频率处的谱峰是必要的*。
+
+下图说明了具有复根的情况与具有实根的情况之间谱的差异
+
+```{code-cell} ipython3
+ω_grid = np.linspace(1e-3, np.pi - 1e-3, 800)
+V_hs = np.array([[1.0, 0.0], [0.0, 0.0]])  # 仅第一个方程中有冲击
+
+# 情况 1：复根 (c=0.6, v=0.8)
+c_complex, v_complex = 0.6, 0.8
+A_complex = samuelson_transition(c_complex, v_complex)
+eig_complex = np.linalg.eigvals(A_complex)
+
+# 情况 2：实根 (c=0.8, v=0.1)
+c_real, v_real = 0.8, 0.1
+A_real = samuelson_transition(c_real, v_real)
+eig_real = np.linalg.eigvals(A_real)
+
+print(
+    f"复根情况 (c={c_complex}, v={v_complex})：特征值 = {eig_complex}")
+print(
+    f"实根情况 (c={c_real}, v={v_real})：特征值 = {eig_real}")
+
+F_complex = spectral_density_var1(A_complex, V_hs, ω_grid)
+F_real = spectral_density_var1(A_real, V_hs, ω_grid)
+
+f11_complex = np.real(F_complex[:, 0, 0])
+f11_real = np.real(F_real[:, 0, 0])
+
+fig, ax = plt.subplots()
+ax.plot(ω_grid / np.pi, f11_complex / np.max(f11_complex), lw=2,
+        label=fr'复根 ($c={c_complex}, v={v_complex}$)')
+ax.plot(ω_grid / np.pi, f11_real / np.max(f11_real), lw=2,
+        label=fr'实根 ($c={c_real}, v={v_real}$)')
+ax.set_xlabel(r'频率 $\omega/\pi$')
+ax.set_ylabel('归一化谱')
+ax.legend(frameon=False)
+plt.show()
+```
+
+对于复根，谱有一个清晰的内部峰值。
+
+对于实根，谱单调递减，不可能有内部峰值。
+
+## 实根可以在一般模型中产生峰值
+
+虽然实正根不能在 Hansen-Samuelson 模型中产生谱峰，{cite:t}`Chow1968` 强调这在一般情况下*并不成立*。
+
+在多元系统中，即使所有特征值都是实数且为正，变量线性组合的谱密度也可以有内部峰值。
+
+### 例子
+
+Chow 构造了以下具有两个实正特征值的明确例子：
+
+```{math}
+:label: chow_real_roots_example
+
+\lambda_1 = 0.1, \quad \lambda_2 = 0.9
+```
+
+```{math}
+:label: chow_real_roots_W
+
+w_{11} = w_{22} = 1, \quad w_{12} = 0.8
+```
+
+```{math}
+:label: chow_real_roots_b
+
+b_{m1} = 1, \quad b_{m2} = -0.01
+```
+
+线性组合 $x_t = b_m^\top y_t$ 的谱密度为：
+
+```{math}
+:label: chow_real_roots_spectrum
+
+f_{mm}(\omega) = \frac{0.9913}{1.01 - 0.2\cos\omega} - \frac{0.001570}{1.81 - 1.8\cos\omega}
+```
+
+Chow 列出了这些值：
+
+| $\omega$ | $0$ | $\pi/8$ | $2\pi/8$ | $3\pi/8$ | $4\pi/8$ | $5\pi/8$ | $6\pi/8$ | $7\pi/8$ | $\pi$ |
+|----------|-----|---------|----------|----------|----------|----------|----------|----------|-------|
+| $f_{mm}(\omega)$ | 1.067 | 1.183 | 1.191 | 1.138 | 1.061 | 0.981 | 0.912 | 0.860 | 0.829 |
+
+在略低于 $\pi/8$ 的 $\omega$ 处（对应约 11 个周期的周期）的峰值"相当明显"。
+
+在下图中，我们重现这个表，但用 Python，我们可以绘制更精细的网格以更准确地找到峰值
+
+```{code-cell} ipython3
+λ1, λ2 = 0.1, 0.9
+w11, w22, w12 = 1.0, 1.0, 0.8
+bm1, bm2 = 1.0, -0.01
+
+# 构造系统
+A_chow_ex = np.diag([λ1, λ2])
+
+# W 是规范冲击协方差；我们需要 V = B W B^T
+# 对于具有不同特征值的对角 A，B = I，所以 V = W
+V_chow_ex = np.array([[w11, w12], [w12, w22]])
+b_chow_ex = np.array([bm1, bm2])
+
+# Chow 的公式
+def chow_spectrum_formula(ω):
+    term1 = 0.9913 / (1.01 - 0.2 * np.cos(ω))
+    term2 = 0.001570 / (1.81 - 1.8 * np.cos(ω))
+    return term1 - term2
+
+# 通过公式和通过我们的一般方法计算
+ω_table = np.array([0, np.pi/8, 2*np.pi/8, 3*np.pi/8, 4*np.pi/8,
+                    5*np.pi/8, 6*np.pi/8, 7*np.pi/8, np.pi])
+f_formula = np.array([chow_spectrum_formula(ω) for ω in ω_table])
+
+# 一般方法
+ω_grid_fine = np.linspace(1e-4, np.pi, 1000)
+F_chow_ex = spectral_density_var1(A_chow_ex, V_chow_ex, ω_grid_fine)
+f_general = spectrum_of_linear_combination(F_chow_ex, b_chow_ex)
+
+# 归一化以匹配 Chow 表的尺度
+scale = f_formula[0] / spectrum_of_linear_combination(
+    spectral_density_var1(
+        A_chow_ex, V_chow_ex, np.array([0.0])), b_chow_ex)[0]
+
+print("Chow 的表（方程 67）：")
+print("ω/π:        ", "  ".join([f"{ω/np.pi:.3f}" for ω in ω_table]))
+print("f_mm(ω):    ", "  ".join([f"{f:.3f}" for f in f_formula]))
+
+fig, ax = plt.subplots(figsize=(9, 4))
+ax.plot(ω_grid_fine / np.pi, f_general * scale, lw=2,
+            label='谱')
+ax.scatter(ω_table / np.pi, f_formula, s=50, zorder=3,
+            label="Chow 的表值")
+
+# 标记峰值
+i_peak = np.argmax(f_general)
+ω_peak = ω_grid_fine[i_peak]
+ax.axvline(ω_peak / np.pi, ls='--', lw=1.0, color='gray', alpha=0.7)
+ax.set_xlabel(r'频率 $\omega/\pi$')
+ax.set_ylabel(r'$f_{mm}(\omega)$')
+ax.legend(frameon=False)
+plt.show()
+
+print(f"\n峰值在 ω/π ≈ {ω_peak/np.pi:.3f}，周期 ≈ {2*np.pi/ω_peak:.1f}")
+```
+
+峰值出现在 $\omega/\pi \approx 0.10$ 处，对应约 20 个周期的周期长度，同样比特征值隐含的确定性周期长得多。
+
+### 斯卢茨基联系
+
+Chow 将这个结果与斯卢茨基 {cite}`slutsky1937` 的发现联系起来，即随机序列的移动平均具有反复出现的周期。
+
+VAR(1) 模型可以写成无限移动平均：
+
+```{math}
+:label: chow_ma_rep
+
+y_t = u_t + A u_{t-1} + A^2 u_{t-2} + \cdots
+```
+
+这相当于用"几何递减"的权重 $A^0, A^1, A^2, \ldots$ 对随机向量 $u_t$ 取无限移动平均。
+
+对于具有 $0 < \lambda < 1$ 的标量过程，不会出现明显的周期。
+
+但对于具有 0 到 1 之间实根的矩阵 $A$，周期*可以*在变量的线性组合中出现。
+
+正如 Chow 所说："当两个（规范）变量都没有明显的周期时……一个线性组合可以在其谱密度中有一个峰值。"
+
+### 一般教训
+
+上面的例子说明了以下核心要点：
+
+1. 在*特定的 Hansen-Samuelson 模型*中，复根对谱峰是必要的
+2. 但在*一般多元系统*中，复根既不必要也不充分
+3. 完整的谱形状依赖于：
+   - $A$ 的特征值
+   - 冲击协方差结构 $V$
+   - 感兴趣的可观测量如何加载于特征模态（向量 $b$）
+
+## 频域中的一个校准模型
+
+{cite:t}`ChowLevitan1969` 使用来自 {cite:t}`Chow1968` 的频域对象来研究一个校准的年度宏观计量经济模型。
+
+他们使用五个年度总量：
+
+- $y_1 = C$（消费），
+- $y_2 = I_1$（设备加库存），
+- $y_3 = I_2$（建筑），
+- $y_4 = R_a$（长期利率），
+- $y_5 = Y_1 = C + I_1 + I_2$（私人国内 GNP），
+
+并加入 $y_6 = y_{1,t-1}$ 以将原始系统重写为一阶形式。
+
+在整个这一节中，频率以每年周期数衡量，$f = \omega/2\pi \in [0, 1/2]$。
+
+遵循论文，我们将每个谱归一化，使其在 $[0, 1/2]$ 上的面积为 1，以便图比较形状而非尺度。
+
+我们的目标是重构转移矩阵 $A$，然后计算并解释模型隐含的谱、增益/相干性和相位差。
+
+### 周期子系统
+
+论文从带有外生输入的简化形式开始，
+
+```{math}
+:label: chow_reduced_full
+
+y_t = A y_{t-1} + C x_t + u_t.
+```
+
+为了研究周期，他们移除归因于 $x_t$ 的确定性成分，并专注于零均值子系统
+
+```{math}
+:label: chow_cycle_system
+
+y_t = A y_{t-1} + u_t.
+```
+
+对于二阶矩，唯一额外的组成部分是协方差矩阵 $V = \mathbb E[u_t u_t^\top]$。
+
+Chow 和 Levitan 通过以下方式从结构参数计算它
+
+```{math}
+:label: chow_v_from_structural
+
+V = M^{-1} \Sigma (M^{-1})^\top
+```
+
+其中 $\Sigma$ 是结构残差的协方差，$M$ 是同期结构系数矩阵。
+
+这里我们将 $A$ 和 $V$ 视为给定，并询问它们对谱和交叉谱意味着什么。
+
+Chow 和 Levitan 报告的 $6 \times 6$ 简化形式冲击协方差矩阵 $V$（按 $10^{-7}$ 缩放）为：
+
+```{math}
+:label: chow_V_matrix
+
+V = \begin{bmatrix}
+8.250 & 7.290 & 2.137 & 2.277 & 17.68 & 0 \\
+7.290 & 7.135 & 1.992 & 2.165 & 16.42 & 0 \\
+2.137 & 1.992 & 0.618 & 0.451 & 4.746 & 0 \\
+2.277 & 2.165 & 0.451 & 1.511 & 4.895 & 0 \\
+17.68 & 16.42 & 4.746 & 4.895 & 38.84 & 0 \\
+0 & 0 & 0 & 0 & 0 & 0
+\end{bmatrix}.
+```
+
+第六行和列为零，因为 $y_6$ 是一个恒等式（滞后的 $y_1$）。
+
+转移矩阵 $A$ 有六个特征根：
+
+```{math}
+:label: chow_eigenvalues
+
+\begin{aligned}
+\lambda_1 &= 0.9999725, \quad \lambda_2 = 0.9999064, \quad \lambda_3 = 0.4838, \\
+\lambda_4 &= 0.0761 + 0.1125i, \quad \lambda_5 = 0.0761 - 0.1125i, \quad \lambda_6 = -0.00004142.
+\end{aligned}
+```
+
+两个根接近于 1，因为两个结构方程是一阶差分的。
+
+一个根（$\lambda_6$）在理论上为零，因为恒等式 $y_5 = y_1 + y_2 + y_3$。
+
+共轭复数对 $\lambda_{4,5}$ 的模为 $|\lambda_4| = \sqrt{0.0761^2 + 0.1125^2} \approx 0.136$。
+
+右特征向量矩阵 $B$（列是对应于 $\lambda_1, \ldots, \lambda_6$ 的特征向量）：
+
+```{math}
+:label: chow_B_matrix
+
+B = \begin{bmatrix}
+-0.008 & 1.143 & 0.320 & 0.283+0.581i & 0.283-0.581i & 0.000 \\
+-0.000 & 0.013 & -0.586 & -2.151+0.742i & -2.151-0.742i & 2.241 \\
+-0.001 & 0.078 & 0.889 & -0.215+0.135i & -0.215-0.135i & 0.270 \\
+1.024 & 0.271 & 0.069 & -0.231+0.163i & -0.231-0.163i & 0.307 \\
+-0.009 & 1.235 & 0.623 & -2.082+1.468i & -2.082-1.468i & 2.766 \\
+-0.008 & 1.143 & 0.662 & 4.772+0.714i & 4.772-0.714i & -4.399
+\end{bmatrix}.
+```
+
+$V$、$\{\lambda_i\}$ 和 $B$ 一起足以计算所有谱和交叉谱密度。
+
+### 重构 $A$ 并计算 $F(\omega)$
+
+论文报告了 $(\lambda, B, V)$，这足以重构
+$A = B \, \mathrm{diag}(\lambda_1,\dots,\lambda_6)\, B^{-1}$，然后计算模型隐含的谱对象。
+
+```{code-cell} ipython3
+λ = np.array([
+    0.9999725, 0.9999064, 0.4838,
+    0.0761 + 0.1125j, 0.0761 - 0.1125j, -0.00004142
+], dtype=complex)
+
+B = np.array([
+    [-0.008, 1.143, 0.320, 0.283+0.581j, 0.283-0.581j, 0.000],
+    [-0.000, 0.013, -0.586, -2.151+0.742j, -2.151-0.742j, 2.241],
+    [-0.001, 0.078, 0.889, -0.215+0.135j, -0.215-0.135j, 0.270],
+    [1.024, 0.271, 0.069, -0.231+0.163j, -0.231-0.163j, 0.307],
+    [-0.009, 1.235, 0.623, -2.082+1.468j, -2.082-1.468j, 2.766],
+    [-0.008, 1.143, 0.662, 4.772+0.714j, 4.772-0.714j, -4.399]
+], dtype=complex)
+
+V = np.array([
+    [8.250, 7.290, 2.137, 2.277, 17.68, 0],
+    [7.290, 7.135, 1.992, 2.165, 16.42, 0],
+    [2.137, 1.992, 0.618, 0.451, 4.746, 0],
+    [2.277, 2.165, 0.451, 1.511, 4.895, 0],
+    [17.68, 16.42, 4.746, 4.895, 38.84, 0],
+    [0, 0, 0, 0, 0, 0]
+]) * 1e-7
+
+D_λ = np.diag(λ)
+A_chow = B @ D_λ @ np.linalg.inv(B)
+A_chow = np.real(A_chow) 
+print("重构 A 的特征值：")
+print(np.linalg.eigvals(A_chow).round(6))
+```
+
+### 规范坐标
+
+Chow 和 Levitan 的规范变换使用 $z_t = B^{-1} y_t$，给出动态 $z_t = D_\lambda z_{t-1} + e_t$。
+
+相应地，规范冲击协方差为
+
+```{math}
+W = B^{-1} V (B^{-1})^\top.
+```
+
+```{code-cell} ipython3
+B_inv = np.linalg.inv(B)
+W = B_inv @ V @ B_inv.T
+print("W 的对角线：")
+print(np.diag(W).round(10))
+```
+
+Chow 和 Levitan 推导了以下谱密度矩阵的闭式公式：
+
+```{math}
+:label: chow_spectral_eigen
+
+F(\omega)
+= B \left[ \frac{w_{ij}}{(1 - \lambda_i e^{-i\omega})(1 - \lambda_j e^{i\omega})} \right] B^\top,
+```
+
+其中 $w_{ij}$ 是规范冲击协方差 $W$ 的元素。
+
+```{code-cell} ipython3
+def spectral_density_chow(λ, B, W, ω_grid):
+    """通过 Chow 的特征分解公式计算谱密度。"""
+    p = len(λ)
+    F = np.zeros((len(ω_grid), p, p), dtype=complex)
+    for k, ω in enumerate(ω_grid):
+        F_star = np.zeros((p, p), dtype=complex)
+        for i in range(p):
+            for j in range(p):
+                denom = (1 - λ[i] * np.exp(-1j * ω)) \
+                    * (1 - λ[j] * np.exp(1j * ω))
+                F_star[i, j] = W[i, j] / denom
+        F[k] = B @ F_star @ B.T
+    return F / (2 * np.pi)
+
+freq = np.linspace(1e-4, 0.5, 5000)     # [0, 1/2] 内每年周期数
+ω_grid = 2 * np.pi * freq               # [0, π] 内弧度
+F_chow = spectral_density_chow(λ, B, W, ω_grid)
+```
+
+让我们绘制消费（$y_1$）和设备加库存（$y_2$）的单变量谱
+
+```{code-cell} ipython3
+variable_names = ['$C$', '$I_1$', '$I_2$', '$R_a$', '$Y_1$']
+freq_ticks = [1/18, 1/9, 1/6, 1/4, 1/3, 1/2]
+freq_labels = [r'$\frac{1}{18}$', r'$\frac{1}{9}$', r'$\frac{1}{6}$',
+               r'$\frac{1}{4}$', r'$\frac{1}{3}$', r'$\frac{1}{2}$']
+
+def paper_frequency_axis(ax):
+    ax.set_xlim([0.0, 0.5])
+    ax.set_xticks(freq_ticks)
+    ax.set_xticklabels(freq_labels)
+    ax.set_xlabel(r'频率 $\omega/2\pi$')
+
+# 归一化谱（面积设为 1）
+S = np.real(np.diagonal(F_chow, axis1=1, axis2=2))[:, :5]
+df = np.diff(freq)
+areas = np.sum(0.5 * (S[1:] + S[:-1]) * df[:, None], axis=0)
+S_norm = S / areas
+mask = freq >= 0.0
+
+fig, axes = plt.subplots(1, 2, figsize=(10, 6))
+
+# 图 I.1：消费（对数刻度）
+axes[0].plot(freq[mask], S_norm[mask, 0], lw=2)
+axes[0].set_yscale('log')
+paper_frequency_axis(axes[0])
+axes[0].set_ylabel(r'归一化 $f_{11}(\omega)$')
+
+# 图 I.2：设备 + 库存（对数刻度）
+axes[1].plot(freq[mask], S_norm[mask, 1], lw=2)
+axes[1].set_yscale('log')
+paper_frequency_axis(axes[1])
+axes[1].set_ylabel(r'归一化 $f_{22}(\omega)$')
+
+plt.tight_layout()
+plt.show()
+
+i_peak = np.argmax(S_norm[mask, 1])
+f_peak = freq[mask][i_peak]
+```
+
+左图对应于消费，随频率单调递减。
+
+它说明了 Granger 关于宏观经济时间序列的"典型谱形状"。
+
+右图对应于设备加库存，显示出最清晰（但仍然非常平坦）的内部频率隆起。
+
+Chow 和 Levitan 将两个图中极低频率的主导地位与强持续性和长期运动联系起来。
+
+极大的低频功率可能源于极接近于 1 的特征值，这在某些方程以一阶差分形式写出时机械地出现。
+
+局部峰值不是自动出现的：复根可能具有小的模，而多元相互作用即使在所有根都为实数时也能产生峰值。
+
+右图中的内部隆起对应于大约三年的周期，谱在大约两到四年的周期上几乎平坦。
+
+（此讨论遵循 {cite}`ChowLevitan1969` 的第 II 节。）
+
+### 变量如何跨频率一起运动
+
+除了单变量谱，我们还可以问变量对如何在每个频率上协变。
+
+**交叉谱** $f_{ij}(\omega) = c_{ij}(\omega) - i \cdot q_{ij}(\omega)$ 分解为共谱 $c_{ij}$ 和正交谱 $q_{ij}$。
+
+**交叉幅度**为 $g_{ij}(\omega) = |f_{ij}(\omega)| = \sqrt{c_{ij}^2 + q_{ij}^2}$。
+
+**平方相干性**衡量频率 $\omega$ 处的线性关联：
+
+```{math}
+:label: chow_coherence
+
+R^2_{ij}(\omega) = \frac{|f_{ij}(\omega)|^2}{f_{ii}(\omega) f_{jj}(\omega)} \in [0, 1].
+```
+
+相干性衡量 $y_i$ 在频率 $\omega$ 处的方差有多少可以由同频率的 $y_j$ "解释"。
+
+高相干性意味着两个序列在该频率上紧密地一起运动。
+
+**增益**是将 $y_i$ 对 $y_j$ 回归时的频率响应系数：
+
+```{math}
+:label: chow_gain
+
+G_{ij}(\omega) = \frac{|f_{ij}(\omega)|}{f_{jj}(\omega)}.
+```
+
+它衡量 $y_i$ 对 $y_j$ 在频率 $\omega$ 处单位变化的反应程度。
+
+例如，低频处增益 0.9 意味着 $y_j$ 中的长周期运动几乎一对一地转化为 $y_i$，而高频处增益 0.3 意味着短周期运动被抑制。
+
+**相位**捕捉领先-滞后关系（以弧度为单位）：
+
+```{math}
+:label: chow_phase
+
+\Delta_{ij}(\omega) = \tan^{-1}\left( \frac{q_{ij}(\omega)}{c_{ij}(\omega)} \right).
+```
+
+```{code-cell} ipython3
+def cross_spectral_measures(F, i, j):
+    """计算变量 i 和 j 之间的相干性、增益（y_i 对 y_j）和相位。"""
+    f_ij = F[:, i, j]
+    f_ii, f_jj = np.real(F[:, i, i]), np.real(F[:, j, j])
+    g_ij = np.abs(f_ij)
+    coherence = (g_ij**2) / (f_ii * f_jj)
+    gain = g_ij / f_jj
+    phase = np.arctan2(-np.imag(f_ij), np.real(f_ij))
+    return coherence, gain, phase
+```
+
+我们现在绘制增益和相干性，如 {cite}`ChowLevitan1969` 的图 II.1–II.4。
+
+```{code-cell} ipython3
+gnp_idx = 4
+
+fig, axes = plt.subplots(1, 2, figsize=(8, 6))
+
+for idx, var_idx in enumerate([0, 1]):
+    coherence, gain, phase = cross_spectral_measures(F_chow, var_idx, gnp_idx)
+    ax = axes[idx]
+
+    ax.plot(freq[mask], coherence[mask],
+            lw=2, label=rf'$R^2_{{{var_idx+1}5}}(\omega)$')
+    ax.plot(freq[mask], gain[mask],
+            lw=2, label=rf'$G_{{{var_idx+1}5}}(\omega)$')
+    paper_frequency_axis(ax)
+    ax.set_ylim([0, 1.0])
+    ax.set_ylabel('增益、相干性')
+    ax.legend(frameon=False, loc='best')
+
+plt.tight_layout()
+plt.show()
+```
+
+增益和相干性模式在各成分之间不同（{cite}`ChowLevitan1969` 的图 II.1–II.2）：
+
+- 消费与私人国内 GNP（左图）：
+    - 增益在极低频率处约为 0.9，但对于短于四年的周期降至 0.4 以下。
+    - 这证明短周期收入运动转化为消费的程度低于长周期运动，与永久收入解释一致。
+    - 相干性始终保持较高。
+- 设备加库存与私人国内 GNP（右图）：
+    - 增益*随频率上升*，短周期时超过 0.5。
+    - 这是加速和波动的短期库存运动的频域特征。
+
+```{code-cell} ipython3
+fig, axes = plt.subplots(1, 2, figsize=(8, 6))
+
+for idx, var_idx in enumerate([2, 3]):
+    coherence, gain, phase = cross_spectral_measures(F_chow, var_idx, gnp_idx)
+    ax = axes[idx]
+
+    ax.plot(freq[mask], coherence[mask],
+            lw=2, label=rf'$R^2_{{{var_idx+3}5}}(\omega)$')
+    ax.plot(freq[mask], gain[mask],
+            lw=2, label=rf'$G_{{{var_idx+3}5}}(\omega)$')
+    paper_frequency_axis(ax)
+    ax.set_ylim([0, 1.0])
+    ax.set_ylabel('增益、相干性')
+    ax.legend(frameon=False, loc='best')
+
+plt.tight_layout()
+plt.show()
+```
+
+- 新建筑与私人国内 GNP（左图）：
+    - 增益在中等周期长度处达到峰值（短周期约为 0.1）。
+    - 两个投资序列的相干性在各频率上都保持相当高。
+- 长期债券收益率与私人国内 GNP（右图）：
+    - 增益在各频率上的变化小于实际活动序列。
+    - 在商业周期频率上与产出的相干性相对较低，使得难以通过反转货币需求方程来解释利率运动。
+
+
+### 领先-滞后关系
+
+相位告诉我们哪个变量在每个频率上领先。
+
+正相位意味着产出领先于该成分；负相位意味着该成分领先于产出。
+
+```{code-cell} ipython3
+fig, ax = plt.subplots()
+
+labels = [r'$\psi_{15}(\omega)/2\pi$', r'$\psi_{25}(\omega)/2\pi$',
+          r'$\psi_{35}(\omega)/2\pi$', r'$\psi_{45}(\omega)/2\pi$']
+
+for var_idx in range(4):
+    coherence, gain, phase = cross_spectral_measures(F_chow, var_idx, gnp_idx)
+    phase_cycles = phase / (2 * np.pi)
+    ax.plot(freq[mask], phase_cycles[mask], lw=2, label=labels[var_idx])
+
+ax.axhline(0, lw=0.8)
+paper_frequency_axis(ax)
+ax.set_ylabel('以周期为单位的相位差')
+ax.set_ylim([-0.25, 0.25])
+ax.set_yticks(np.arange(-0.25, 0.3, 0.05), minor=True)
+ax.legend(frameon=False)
+plt.tight_layout()
+plt.show()
+```
+
+相位关系揭示了：
+
+- 产出领先消费一小部分周期（6 年周期约 0.06 个周期，3 年周期约 0.04 个周期）。
+- 设备加库存倾向于领先产出（6 年周期约 0.07 个周期，3 年周期约 0.03 个周期）。
+- 新建筑在低频处领先，在高频处接近同步。
+- 债券收益率略微滞后产出，在时间上保持接近同步。
+
+这些隐含的领先和滞后大致与其他地方报告的转折点时机总结一致，同一模型的模拟在转折点处产生类似的领先-滞后排序（{cite}`ChowLevitan1969` 的图 III）。
+
+### 谱形状的组成部分
+
+每个特征值通过*标量核*贡献一个特征谱形状
+
+```{math}
+:label: chow_scalar_kernel
+
+g_i(\omega) = \frac{1 - |\lambda_i|^2}{|1 - \lambda_i e^{-i\omega}|^2} = \frac{1 - |\lambda_i|^2}{1 + |\lambda_i|^2 - 2 \text{Re}(\lambda_i) \cos\omega + 2 \text{Im}(\lambda_i) \sin\omega}.
+```
+
+对于实数 $\lambda_i$，这简化为
+
+```{math}
+g_i(\omega) = \frac{1 - \lambda_i^2}{1 + \lambda_i^2 - 2\lambda_i \cos\omega}.
+```
+
+每个可观测的谱密度是这些核的线性组合（加上交叉项）。
+
+下面，我们绘制每个特征值的标量核，以了解它们如何塑造整体谱
+
+```{code-cell} ipython3
+def scalar_kernel(λ_i, ω_grid):
+    """标量谱核 g_i(ω)。"""
+    λ_i = complex(λ_i)
+    mod_sq = np.abs(λ_i)**2
+    return np.array(
+        [(1 - mod_sq) / np.abs(1 - λ_i * np.exp(-1j * ω))**2 
+        for ω in ω_grid])
+
+fig, ax = plt.subplots(figsize=(10, 5))
+for i, λ_i in enumerate(λ):
+    if np.abs(λ_i) > 0.01:
+        g_i = scalar_kernel(λ_i, ω_grid)
+        label = f'$\\lambda_{i+1}$ = {λ_i:.4f}' \
+        if np.isreal(λ_i) else f'$\\lambda_{i+1}$ = {λ_i:.3f}'
+        ax.semilogy(freq, g_i, label=label, lw=2)
+
+ax.set_xlabel(r'频率 $\omega/2\pi$')
+ax.set_ylabel('$g_i(\\omega)$')
+ax.set_xlim([1/18, 0.5])
+ax.set_xticks(freq_ticks)
+ax.set_xticklabels(freq_labels)
+ax.legend(frameon=False)
+plt.show()
+```
+
+该图揭示了特征值大小如何塑造谱贡献：
+
+- *接近于 1 的特征值*（$\lambda_1, \lambda_2 \approx 1$）产生在低频处急剧达到峰值的核，因为这些驱动了上面谱中看到的强低频功率。
+- *中等特征值*（$\lambda_3 \approx 0.48$）贡献一个更平坦的成分，将功率更均匀地分布在各频率上。
+- *复数对*（$\lambda_{4,5}$）的模太小（$|\lambda_{4,5}| \approx 0.136$），以至于其核几乎平坦，太弱而无法产生明显的内部峰值。
+
+这个分解解释了为什么谱看起来是这样的：接近于 1 的特征值占主导地位，将方差集中在极低频率处。
+
+复数对尽管在原则上使振荡动态成为可能，但模不足，无法产生可见的谱峰。
+
+## 总结
+
+{cite:t}`Chow1968` 得出了几个对理解商业周期仍然相关的结论。
+
+加速原理得到了强有力的经验支持：投资方程中滞后产出的负系数是跨数据集的稳健发现。
+
+特征值与谱峰之间的关系比乍看起来更为微妙：
+
+- 复根保证振荡的自协方差，但它们对明显的谱峰既不必要也不充分。
+
+- 特别是在 Hansen–Samuelson 模型中，复根*确实*对峰值是必要的。
+
+- 但在一般多元系统中，即使是实根也可以通过冲击和特征向量载荷的相互作用产生峰值。
+
+{cite:t}`ChowLevitan1969` 演示了这些对象在一个校准系统中的样子：来自接近于 1 的特征值的强低频功率、频率相关的增益和相干性，以及随周期长度变化的领先-滞后关系。
+
+他们的结果与 Granger 关于经济时间序列的"典型谱形状"一致。
+
+即一个随频率单调递减的函数，由某些方程以一阶差分形式指定时出现的接近于 1 的特征值驱动。
+
+理解这种形状是否反映了真实的数据生成过程，需要分析结构计量经济模型隐含的谱密度。
+
+## 练习
+
+```{exercise}
+:label: chow_cycles_ex1
+
+在 Hansen-Samuelson 模型中，为加速数 $v$ 的几个值并排绘制脉冲响应和谱，展示加速强度如何影响时域和频域特征。
+
+使用与正文相同的 $v$ 值：$v \in \{0.2, 0.4, 0.6, 0.8, 0.95\}$，$c = 0.6$。
+```
+
+```{solution-start} chow_cycles_ex1
+:class: dropdown
+```
+
+这是一个解法：
+
+```{code-cell} ipython3
+v_grid_ex1 = [0.2, 0.4, 0.6, 0.8, 0.95]
+c_ex1 = 0.6
+freq_ex1 = np.linspace(1e-4, 0.5, 2000)
+ω_grid_ex1 = 2 * np.pi * freq_ex1
+V_ex1 = np.array([[1.0, 0.0], [0.0, 0.0]])
+T_irf_ex1 = 40
+
+fig, axes = plt.subplots(1, 2, figsize=(12, 5))
+
+for v in v_grid_ex1:
+    A = samuelson_transition(c_ex1, v)
+
+    # 脉冲响应（左图）
+    s = np.array([1.0, 0.0])
+    irf = np.empty(T_irf_ex1 + 1)
+    for t in range(T_irf_ex1 + 1):
+        irf[t] = s[0]
+        s = A @ s
+    axes[0].plot(range(T_irf_ex1 + 1), irf, lw=2, label=f'$v={v}$')
+
+    # 谱（右图）
+    F = spectral_density_var1(A, V_ex1, ω_grid_ex1)
+    f11 = np.real(F[:, 0, 0])
+    df = np.diff(freq_ex1)
+    area = np.sum(0.5 * (f11[1:] + f11[:-1]) * df)
+    f11_norm = f11 / area
+    axes[1].plot(freq_ex1, f11_norm, lw=2, label=f'$v={v}$')
+
+axes[0].axhline(0, lw=0.8, color='gray')
+axes[0].set_xlabel('时间')
+axes[0].set_ylabel(r'$Y_t$')
+axes[0].legend(frameon=False)
+
+axes[1].set_xlabel(r'频率 $\omega/2\pi$')
+axes[1].set_ylabel('归一化谱')
+axes[1].set_xlim([0, 0.5])
+axes[1].set_yscale('log')
+axes[1].legend(frameon=False)
+
+plt.tight_layout()
+plt.show()
+```
+
+随着 $v$ 增加，特征值接近单位圆：振荡在时域中变得更加持久（左），谱峰在频域中变得更尖锐（右）。
+
+复根在内部频率处产生明显的峰值——这是商业周期的谱特征。
+
+```{solution-end}
+```
+
+```{exercise}
+:label: chow_cycles_ex2
+
+对 Hansen-Samuelson 模型数值验证谱峰条件 {eq}`chow_hs_peak_condition`。
+
+1. 对于固定 $\theta = 60°$ 的一系列特征值模 $r \in [0.3, 0.99]$，计算：
+   - 来自公式的理论峰值频率：$\cos\omega = \frac{1+r^2}{2r}\cos\theta$
+   - 通过数值最大化谱密度得到的实际峰值频率
+2. 在同一图上绘制两者并验证它们匹配。
+3. 确定没有有效峰值存在的 $r$ 范围（当条件 {eq}`chow_hs_necessary` 被违反时）。
+```
+
+```{solution-start} chow_cycles_ex2
+:class: dropdown
+```
+
+这是一个解法：
+
+```{code-cell} ipython3
+θ_ex = np.pi / 3  # 60 度
+r_grid = np.linspace(0.3, 0.99, 50)
+ω_grid_ex = np.linspace(1e-3, np.pi - 1e-3, 1000)
+V_hs_ex = np.array([[1.0, 0.0], [0.0, 0.0]])
+
+ω_theory = []
+ω_numerical = []
+
+for r in r_grid:
+    # 理论峰值
+    factor = (1 + r**2) / (2 * r)
+    cos_ω = factor * np.cos(θ_ex)
+    if -1 < cos_ω < 1:
+        ω_theory.append(np.arccos(cos_ω))
+    else:
+        ω_theory.append(np.nan)
+
+    # 来自谱密度的数值峰值
+    # 构造具有特征值 r*exp(+-iθ) 的 Hansen-Samuelson
+    # 这对应于 c + v = 2r*cos(θ), v = r^2
+    v = r**2
+    c = 2 * r * np.cos(θ_ex) - v
+    A_ex = samuelson_transition(c, v)
+    F_ex = spectral_density_var1(A_ex, V_hs_ex, ω_grid_ex)
+    f11 = np.real(F_ex[:, 0, 0])
+    i_max = np.argmax(f11)
+
+    # 只有当峰值不在边界时才算作峰值
+    if 5 < i_max < len(ω_grid_ex) - 5:
+        ω_numerical.append(ω_grid_ex[i_max])
+    else:
+        ω_numerical.append(np.nan)
+
+ω_theory = np.array(ω_theory)
+ω_numerical = np.array(ω_numerical)
+
+fig, axes = plt.subplots(1, 2, figsize=(12, 4))
+
+# 绘制峰值频率
+axes[0].plot(r_grid, ω_theory / np.pi, lw=2, label="Chow 的公式")
+axes[0].plot(r_grid, ω_numerical / np.pi, 'o', markersize=4, label='数值')
+axes[0].axhline(θ_ex / np.pi, ls='--', lw=1.0, color='gray', label=r'$\theta/\pi$')
+axes[0].set_xlabel('特征值模 $r$')
+axes[0].set_ylabel(r'峰值频率 $\omega^*/\pi$')
+axes[0].legend(frameon=False)
+
+# 绘制因子 (1+r^2)/2r 以显示峰值何时有效
+axes[1].plot(r_grid, (1 + r_grid**2) / (2 * r_grid), lw=2)
+axes[1].axhline(1 / np.cos(θ_ex), ls='--', lw=1.0, color='red',
+                label=f'阈值 = 1/cos({np.rad2deg(θ_ex):.0f}°) = {1/np.cos(θ_ex):.2f}')
+axes[1].set_xlabel('特征值模 $r$')
+axes[1].set_ylabel(r'$(1+r^2)/2r$')
+axes[1].legend(frameon=False)
+
+plt.tight_layout()
+plt.show()
+
+# 找到没有峰值存在的阈值 r
+valid_mask = ~np.isnan(ω_theory)
+if valid_mask.any():
+    r_threshold = r_grid[valid_mask][0]
+    print(f"峰值存在于 r >= {r_threshold:.2f}")
+```
+
+理论和数值峰值频率紧密匹配。
+
+当 $r \to 1$ 时，峰值频率收敛到 $\theta$。
+
+对于较小的 $r$，因子 $(1+r^2)/2r$ 超过阈值，不存在有效峰值。
+
+```{solution-end}
+```
+
+```{exercise}
+:label: chow_cycles_ex3
+
+在"实根但有峰值"的例子中，保持 $A$ 固定，并将冲击相关性（$V$ 的非对角元）在 $0$ 和 $0.99$ 之间变化。
+
+内部频率峰值何时出现，它的位置如何变化？
+```
+
+```{solution-start} chow_cycles_ex3
+:class: dropdown
+```
+
+这是一个解法：
+
+```{code-cell} ipython3
+A_ex3 = np.diag([0.1, 0.9])
+b_ex3 = np.array([1.0, -0.01])
+corr_grid = np.linspace(0, 0.99, 50)
+peak_periods = []
+for corr in corr_grid:
+    V_ex3 = np.array([[1.0, corr], [corr, 1.0]])
+    F_ex3 = spectral_density_var1(A_ex3, V_ex3, ω_grid_ex)
+    f_x = spectrum_of_linear_combination(F_ex3, b_ex3)
+    i_max = np.argmax(f_x)
+    if 5 < i_max < len(ω_grid_ex) - 5:
+        peak_periods.append(2 * np.pi / ω_grid_ex[i_max])
+    else:
+        peak_periods.append(np.nan)
+
+fig, ax = plt.subplots(figsize=(8, 4))
+ax.plot(corr_grid, peak_periods, marker='o', lw=2, markersize=4)
+ax.set_xlabel('冲击相关性')
+ax.set_ylabel('峰值周期')
+plt.show()
+
+threshold_idx = np.where(~np.isnan(peak_periods))[0]
+if len(threshold_idx) > 0:
+    print(
+        f"当相关性 >= {corr_grid[threshold_idx[0]]:.2f} 时出现内部峰值")
+```
+
+内部峰值只有在冲击相关性超过某个阈值时才出现。
+
+这说明谱峰依赖于完整的系统结构，而不仅仅是特征值。
+
+```{solution-end}
+```
+
+```{exercise}
+:label: chow_cycles_ex4
+
+使用校准的 Chow-Levitan 参数，用以下方法计算自协方差矩阵 $\Gamma_0, \Gamma_1, \ldots, \Gamma_{10}$：
+
+1. 递归 $\Gamma_k = A \Gamma_{k-1}$，其中 $\Gamma_0$ 来自李雅普诺夫方程。
+2. Chow 的特征分解公式 $\Gamma_k = B D_\lambda^k \Gamma_0^* B^\top$，其中 $\Gamma_0^*$ 是规范协方差。
+
+验证两种方法给出相同的结果。
+```
+
+```{solution-start} chow_cycles_ex4
+:class: dropdown
+```
+
+这是一个解法：
+
+```{code-cell} ipython3
+from scipy.linalg import solve_discrete_lyapunov
+
+Γ_0_lyap = solve_discrete_lyapunov(A_chow, V)
+Γ_recursion = [Γ_0_lyap]
+for k in range(1, 11):
+    Γ_recursion.append(A_chow @ Γ_recursion[-1])
+
+p = len(λ)
+Γ_0_star = np.zeros((p, p), dtype=complex)
+for i in range(p):
+    for j in range(p):
+        Γ_0_star[i, j] = W[i, j] / (1 - λ[i] * λ[j])
+
+Γ_eigen = []
+for k in range(11):
+    D_k = np.diag(λ**k)
+    Γ_eigen.append(np.real(B @ D_k @ Γ_0_star @ B.T))
+
+print("Γ_5 的比较（前 3x3 块）：")
+print("\n递归方法：")
+print(np.real(Γ_recursion[5][:3, :3]).round(10))
+print("\n特征分解方法：")
+print(Γ_eigen[5][:3, :3].round(10))
+print("\n最大绝对差：", 
+        np.max(np.abs(np.real(Γ_recursion[5]) - Γ_eigen[5])))
+```
+
+两种方法产生基本相同的结果，直到数值精度。
+
+```{solution-end}
+```
+
+```{exercise}
+:label: chow_cycles_ex5
+
+通过将 $\lambda_3$ 从 $0.4838$ 改为 $0.95$ 来修改 Chow-Levitan 模型。
+
+1. 重新计算谱密度。
+2. 这个变化如何影响每个变量的谱形状？
+3. 什么经济解释可能对应于这个参数变化？
+```
+
+```{solution-start} chow_cycles_ex5
+:class: dropdown
+```
+
+这是一个解法：
+
+```{code-cell} ipython3
+# 修改 λ_3 并重构转移矩阵
+λ_modified = λ.copy()
+λ_modified[2] = 0.95
+D_λ_mod = np.diag(λ_modified)
+A_mod = np.real(B @ D_λ_mod @ np.linalg.inv(B))
+
+# 使用原始 V 通过 VAR(1) 公式计算谱
+F_mod = spectral_density_var1(A_mod, V, ω_grid)
+F_orig = spectral_density_var1(A_chow, V, ω_grid)
+
+# 绘制产出 (Y_1) 的谱比率
+f_orig = np.real(F_orig[:, 4, 4])
+f_mod = np.real(F_mod[:, 4, 4])
+
+fig, ax = plt.subplots()
+ax.plot(freq, f_mod / f_orig, lw=2)
+ax.axhline(1.0, ls='--', lw=1, color='gray')
+paper_frequency_axis(ax)
+ax.set_ylabel(r"比率：$Y_1$ 的修改后 / 原始谱")
+plt.show()
+```
+
+接近于 1 的特征值（$\lambda_1, \lambda_2 \approx 0.9999$）如此强烈地主导产出谱，以至于将 $\lambda_3$ 从 0.48 改为 0.95 只产生较小的相对影响。
+
+比率图揭示了这个变化：修改后的谱在低到中频处功率略多，在高频处略少。
+
+从经济上讲，增加 $\lambda_3$ 为它所支配的模态增加了持续性。
+
+```{solution-end}
+```

--- a/lectures/information_market_equilibrium.md
+++ b/lectures/information_market_equilibrium.md
@@ -1,0 +1,1337 @@
+---
+jupytext:
+  text_representation:
+    extension: .md
+    format_name: myst
+    format_version: 0.13
+    jupytext_version: 1.17.1
+kernelspec:
+  display_name: Python 3 (ipykernel)
+  language: python
+  name: python3
+translation:
+  title: 信息与市场均衡
+  headings:
+    Overview: 概述
+    Setup: 设定
+    Setup::Preferences, endowments, and the unknown state: 偏好、禀赋与未知状态
+    Setup::The informed agent's problem: 知情代理人的问题
+    Price revelation: 价格揭示
+    Price revelation::Blackwell sufficiency: Blackwell 充分性
+    Price revelation::Two interpretations: 两种解释
+    Price revelation::Two interpretations::Insider trading in a stock market: 股票市场中的内幕交易
+    Price revelation::Two interpretations::Price as a quality signal: 价格作为质量信号
+    Invertibility and the elasticity of substitution: 可逆性与替代弹性
+    Invertibility and the elasticity of substitution::The two-state first-order condition: 两状态一阶条件
+    Invertibility and the elasticity of substitution::CES utility: CES 效用
+    Invertibility and the elasticity of substitution::Equilibrium price as a function of the posterior: 均衡价格作为后验的函数
+    Invertibility and the elasticity of substitution::Why monotonicity depends on $\sigma$: 为什么单调性取决于 $\sigma$
+    Bayesian price expectations in a dynamic economy: 动态经济中的贝叶斯价格预期
+    Bayesian price expectations in a dynamic economy::A stochastic exchange economy: 一个随机交换经济
+    Bayesian price expectations in a dynamic economy::The identification problem: 识别问题
+    Bayesian price expectations in a dynamic economy::Bayesian updating: 贝叶斯更新
+    Bayesian price expectations in a dynamic economy::The convergence theorem: 收敛定理
+    Simulating Bayesian learning from prices: 从价格中模拟贝叶斯学习
+    Simulating Bayesian learning from prices::Price expectations vs. rational expectations: 价格预期 vs. 理性预期
+    Simulating Bayesian learning from prices::Learning the reduced form without identifying the structure: 学到简约形式而不识别结构
+    Exercises: 练习
+---
+
+(information_market_equilibrium)=
+```{raw} jupyter
+<div id="qe-notebook-header" align="right" style="text-align:right;">
+        <a href="https://quantecon.org/" title="quantecon.org">
+                <img style="width:250px;display:inline;"
+                width="250px"
+                src="https://assets.quantecon.org/img/qe-menubar-logo.svg"
+                alt="QuantEcon">
+        </a>
+</div>
+```
+
+# 信息与市场均衡
+
+```{contents} Contents
+:depth: 2
+```
+
+## 概述
+
+本讲研究关于**价格的信息作用**的两个问题，这两个问题由 {cite:t}`kihlstrom_mirman1975` 提出并回答。
+
+1. *价格何时传递内部信息？*
+   - 一位知情的内部人观察到与未知世界状态相关的私有信号，并据此调整需求。
+   - 均衡价格随之变动。
+   - 在什么条件下，外部观察者可以从均衡价格*推断*出内部人的后验分布？
+
+2. *贝叶斯价格预期会收敛吗？*
+   - 在一个平稳的随机交换经济中，一位不知情的观察者利用市场价格的历史和贝叶斯法则来形成关于经济结构的信念，进而形成关于其所诱导的价格分布的信念。
+   - 这些预期最终会与一位完全知情的观察者的预期一致吗？
+
+Kihlstrom 和 Mirman 的回答依赖于统计学中的两个经典思想：
+
+- **Blackwell 充分性**：如果知道随机变量 $\tilde{y}$ 就能给出 $\tilde{y}'$ 所包含的关于状态的所有信息，那么就称随机变量 $\tilde{y}$ 相对于某个未知状态对随机变量 $\tilde{y}'$ 是*充分的*。
+- **贝叶斯一致性**：随着样本增长，后验信念会排除那些隐含错误**价格分布**的模型，因此即使无法从价格中识别出结构，后验对真实**简约形式**的质量仍会收敛到一。
+
+{cite:t}`kihlstrom_mirman1975` 的重要发现是：
+
+- 均衡价格能够传递内部信息，*当且仅当*从内部人后验分布到均衡价格的映射在信号实际可能产生的后验集合上是一一对应的。
+  - 对于两状态的情形（$S = 2$），当知情者的效用是位似的，且替代弹性处处小于一或处处大于一时，可逆性成立。
+- 在动态经济中，随着信息的累积，贝叶斯价格预期会收敛到**理性预期**，即使无法仅从价格中识别出深层结构。
+
+```{note}
+{cite:t}`kihlstrom_mirman1975` 以细致的计量经济学家所采用的方式使用了"简约形式"和"结构"模型这两个术语。
+
+简约形式模型和结构模型成对出现。
+
+对于每一个结构或结构模型，都存在一个简约形式，或者一组对应于不同可能回归的简约形式。
+```
+
+本讲的组织结构如下。
+
+1. 建立静态两商品模型并定义均衡。
+2. 陈述价格揭示定理和可逆性条件。
+3. 用 CES 和科布-道格拉斯偏好的数值例子来说明可逆性及其失效。
+4. 引入动态随机经济并推导贝叶斯收敛结果。
+5. 模拟从价格观测中进行的贝叶斯学习。
+
+本讲以 {doc}`blackwell_kihlstrom` 和 {doc}`likelihood_bayes` 中的思想为基础。
+
+我们首先导入一些 Python 包。
+
+```{code-cell} ipython3
+import numpy as np
+import matplotlib.pyplot as plt
+from scipy.optimize import brentq
+from scipy.stats import norm
+```
+
+
+## 设定
+
+### 偏好、禀赋与未知状态
+
+该经济有两种商品。
+
+商品 2 是计价商品（价格标准化为 1）。
+
+商品 1 以价格 $p > 0$ 交易。
+
+一个未知参数 $\bar{a}$ 影响商品 1 的价值。
+
+代理人 $i$ 从一束商品 $(x_1^i, x_2^i)$ 中获得的期望效用为
+
+$$
+U^i(x_1^i, x_2^i)
+  = \sum_{s=1}^{S} u^i(a_s x_1^i,\, x_2^i)\, P^i(\bar{a} = a_s),
+$$
+
+其中 $P^i$ 是代理人 $i$ 在有限状态空间 $A = \{a_1, \ldots, a_S\}$ 上的主观概率分布。
+
+每个代理人初始拥有商品 2 的禀赋 $w^i$ 以及代表性企业的一份份额 $\theta^i$。
+
+在该论文的形式模型中，一家企业根据 $y_1 = f(y_2)$（其中 $f' < 0$）将商品 2 转化为商品 1，并选择生产以最大化
+
+$$
+\pi(p) = \max_{y_2 \leq 0} \{p f(y_2) + y_2\}.
+$$
+
+企业的利润 $\pi$ 随后按份额 $\theta^i$ 分配给家庭。
+
+代理人 $i$ 的预算约束是
+
+$$
+p x_1^i + x_2^i = w^i + \theta^i \pi.
+$$
+
+代理人在预算约束下最大化期望效用。
+
+**竞争均衡**是一个能同时出清两个市场的价格 $\hat{p}$。
+
+在所维持的凸性假设下，均衡存在，并且遵循 {cite:t}`kihlstrom_mirman1975`，我们假设均衡价格是唯一的，从而可以将 $\hat p = p(\mu)$ 写作知情代理人后验的一个良好定义的函数。
+
+在接下来的大部分内容中，生产方面只通过所诱导的均衡价格映射发挥作用，因此当我们转向数值说明时，我们将略去生产，并使用纯交换/投资组合的解释，以保持计算的透明性。
+
+### 知情代理人的问题
+
+假设**代理人 1**（内部人）在交易前观察到一个与 $\bar{a}$ 相关的私有信号 $\tilde{y}$，其中 $\tilde{y}$ 取值于有限集合 $Y$。
+
+在信号到达之前，代理人 1 拥有先验信念 $\mu_0 = P^1$。
+
+在观察到 $\tilde{y} = y$ 后，代理人 1 通过贝叶斯法则更新到**后验** $\mu_y = (\mu_{y1}, \ldots, \mu_{yS})$：
+
+$$
+\mu_{ys} = P(\bar{a} = a_s \mid \tilde{y} = y).
+$$
+
+由于代理人 1 的需求依赖于 $\mu_y$，新的均衡价格满足
+
+$$
+\hat{p} = p(\mu_y).
+$$
+
+看到 $\hat{p}$ 但看不到 $\tilde{y}$ 的外部观察者可以尝试从价格中*倒推*出内部人的后验。
+
+定义已实现后验的集合
+
+$$
+M = \{\mu_y : y \in Y,\; P(\tilde y = y) > 0\}.
+$$
+
+关键问题是映射 $\mu \mapsto p(\mu)$ 在 $M$ 上是否一一对应。
+
+为了回答这个问题，我们现在将"价格中的信息"翻译成 Blackwell 的充分性语言。
+
+(price_revelation_theorem)=
+## 价格揭示
+
+### Blackwell 充分性
+
+如果观察均衡价格与直接观察信号 $\tilde{y}$ 对 $\bar{a}$ 的信息量相同，那么价格变量 $p(\mu_{\tilde{y}})$ 就*准确地传递*了内部人的私有信息。
+
+在 Blackwell 的语言中（{cite:t}`blackwell1951` 和 {cite:t}`blackwell1953`），这意味着 $p(\mu_{\tilde{y}})$ 对 $\tilde{y}$ 是**充分的**。
+
+```{prf:definition} 充分性
+:label: ime_def_sufficiency
+
+如果存在一个**独立于** $\bar{a}$ 的条件分布 $P(y' \mid y)$，使得
+
+$$
+\phi'_a(y') = \sum_{y \in Y} P(y' \mid y)\, \phi_a(y)
+\quad \text{对所有 } a \text{ 和所有 } y',
+$$
+
+其中 $\phi_a(y) = P(\tilde{y} = y \mid \bar{a} = a)$，那么随机变量 $\tilde{y}$ 相对于 $\bar{a}$ 对 $\tilde{y}'$ 是*充分的*。
+
+因此，一旦知道 $\tilde{y}$，$\tilde{y}'$ 就不再提供关于 $\bar{a}$ 的额外信息。
+```
+
+{cite:t}`kihlstrom_mirman1975` 证明了
+
+```{prf:lemma} 后验充分性
+:label: ime_lemma_posterior_sufficiency
+
+后验分布 $\mu_{\tilde{y}}$ 是 $\tilde{y}$ 的一个充分统计量。
+```
+
+```{prf:proof} （概要）
+后验 $\mu_{\tilde{y}}$ 满足
+
+$$
+P(\bar{a} = a_s \mid \mu_{\tilde{y}} = \mu_y,\; \tilde{y} = y) = \mu_{ys}
+  = P(\bar{a} = a_s \mid \mu_{\tilde{y}} = \mu_y).
+$$
+
+该恒等式表明，一旦知道后验，以原始信号 $\tilde y$ 为条件并不会改变关于 $\bar a$ 的信念。
+
+等价地，给定 $\mu_{\tilde y}$ 时 $\tilde y$ 的条件分布独立于 $\bar a$，因此 $\mu_{\tilde y}$ 在 Blackwell 意义下对 $\tilde y$ 是充分的。
+```
+
+现在让我们考虑从信念到价格的映射。
+
+```{prf:theorem} 价格揭示
+:label: ime_theorem_price_revelation
+
+在上述模型中，价格随机变量 $p(\mu_{\tilde{y}})$ 对随机变量 $\tilde{y}$ 是充分的，当且仅当函数 $p(P^1)$ 在价格集合
+
+$$
+\mathcal{P} = \Bigl\{\, p(\mu_y) : y \in Y,\;
+  P(\tilde{y} = y) = \sum_{a \in A} \phi_a(y)\,\mu_0(a) > 0 \Bigr\}
+$$
+
+上是可逆的。
+```
+
+其逻辑是
+
+$$
+\tilde y \quad \longrightarrow \quad \mu_{\tilde y} \quad \longrightarrow \quad
+p(\mu_{\tilde y}).
+$$
+
+根据 {prf:ref}`ime_lemma_posterior_sufficiency`，第一个箭头没有损失关于 $\bar a$ 的信息，而该定理询问的是第二个箭头何时也没有损失信息。
+
+证明分为两部分。
+
+如果 $p(\cdot)$ 在 $M$ 上是一一对应的，那么观察价格就等价于观察后验本身，因为
+
+$$
+P(\mu_{\tilde y} = \mu \mid p(\mu_{\tilde y}) = p)
+= \begin{cases}
+1 & \text{如果 } \mu = p^{-1}(p), \\
+0 & \text{否则。}
+\end{cases}
+$$
+
+这个条件分布独立于状态，因此价格对后验是充分的；结合 {prf:ref}`ime_lemma_posterior_sufficiency`，价格因而对信号是充分的。
+
+反之，如果 $M$ 中两个不同的后验产生了相同的价格，那么价格的观察者就无法分辨发生的是哪个后验，而该论文正式表明，在这种情况下，给定价格时后验的条件分布将依赖于状态，因此价格不可能是充分的。
+
+在转向可逆性本身之前，记住该论文所强调的两种经济解释是有帮助的。
+
+### 两种解释
+
+#### 股票市场中的内幕交易
+
+商品 1 是一种具有随机回报 $\bar{a}$ 的风险资产；商品 2 是"货币"。
+
+内部人的需求揭示了关于回报的私有信息。
+
+如果可逆性条件成立，外部观察者就可以从均衡股票价格中读出内部人的后验分布——即内部人信号所携带的关于 $\bar a$ 的有用信息。
+
+#### 价格作为质量信号
+
+商品 1 的质量 $\bar{a}$ 是不确定的。
+
+有经验的消费者（曾试用过该商品）观察到一个与质量相关的信号，并据此购买。
+
+不知情的消费者只要可逆性成立，就可以从市场价格推断质量。
+
+(invertibility_conditions)=
+## 可逆性与替代弹性
+
+信念到价格的映射何时不可逆？
+
+{prf:ref}`ime_theorem_invertibility_conditions` 表明，对于一个两状态经济（$S = 2$），答案取决于代理人 1 的效用函数的**替代弹性** $\sigma$。
+
+在陈述该定理之前，先看看该论文论证中的两个中间步骤是有帮助的。
+
+```{prf:lemma} 相同价格意味着相同配置
+:label: ime_lemma_same_price_same_allocation
+
+假设 $u^i$ 具有连续的一阶偏导数，且 $u^i$ 是拟凹的。
+
+设 $p \in \mathcal{P}$。
+
+如果存在 $M$ 中的两个测度 $\mu^*$ 和 $\mu'$，使得 $p(\mu^*, P^2, \ldots, P^n) = p(\mu', P^2, \ldots, P^n) = p$，那么
+
+$$
+x^i(\mu^*, P^2, \ldots, P^n) = x^i(\mu', P^2, \ldots, P^n), \quad
+i = 1, \ldots, n.
+$$
+```
+
+固定除代理人 1 之外所有代理人的信念。
+
+该引理表明，如果代理人 1 的两个后验信念 $\mu^*$ 和 $\mu'$ 都支持相同的均衡价格 $p$，那么它们对每一位交易者都支持相同的均衡配置。
+
+其直觉是，当价格不变时，不知情交易者的需求也不变，因此市场出清迫使知情代理人的商品束也保持不变。
+
+该引理使我们能够将知情代理人的均衡商品束定义为价格的一个函数：
+
+$$
+x(p) = (x_1(p), x_2(p)).
+$$
+
+在全文中，$u^i_j$ 表示 $u^i$ 对其第 $j$ 个参数的偏导数。
+
+每当知情代理人对两种商品都消费正的数量时，在后验 $\mu$ 下 $x(p)$ 的最优性给出了内部一阶条件
+
+$$
+p = \frac{\sum_{s=1}^S a_s u_1^1(a_s x_1(p), x_2(p))\, \mu(a_s)}
+         {\sum_{s=1}^S u_2^1(a_s x_1(p), x_2(p))\, \mu(a_s)}.
+$$
+
+对于一个固定的价格 $p$，商品束 $x(p)$ 也是固定的，因此可逆性归结为这个方程是否有唯一的后验 $\mu$。
+
+```{prf:lemma} 给定价格下的唯一后验
+:label: ime_lemma_unique_posterior
+
+假设 $u^1$ 的一阶偏导数存在，且 $u^1$ 是拟凹的。
+
+同时假设代理人 1 总是消费两种商品的正数量。
+
+那么，如果对每个 $p \in \mathcal{P}$ 都存在唯一的概率测度 $\mu \in M$ 使得
+
+$$
+\frac{\sum_{s=1}^S a_s\, u^1_1(a_s x_1(p), x_2(p))\, \mu(a_s)}
+     {\sum_{s=1}^S u^1_2(a_s x_1(p), x_2(p))\, \mu(a_s)} = p,
+$$
+
+那么 $p(P^1)$ 在 $\mathcal{P}$ 上是可逆的。
+```
+
+如果两个不同的后验给出相同的价格，那么根据 {prf:ref}`ime_lemma_same_price_same_allocation`，它们将共享相同的商品束 $x(p)$，这与在该价格下求解一阶条件的后验的唯一性相矛盾。
+
+### 两状态一阶条件
+
+当 $S = 2$ 且 $\mu = (q,\, 1-q)$ 时，定义
+
+$$
+\alpha_s(p) = a_s\, u^1_1(a_s x_1(p),\, x_2(p)), \qquad
+\beta_s(p)  = u^1_2(a_s x_1(p),\, x_2(p)), \qquad s = 1, 2.
+$$
+
+那么一阶条件变为
+
+$$
+p = \frac{\alpha_1(p)\, q + \alpha_2(p)\, (1-q)}
+         {\beta_1(p)\, q + \beta_2(p)\, (1-q)}.
+$$
+
+在固定价格 $p$ 处，数量 $\alpha_s(p)$ 和 $\beta_s(p)$ 是常数，因此后验的唯一性与求解此方程的标量 $q$ 的唯一性是相同的。
+
+```{prf:theorem} 可逆性条件
+:label: ime_theorem_invertibility_conditions
+
+假设 $u^1$ 的一阶偏导数存在，且 $u^1$ 是拟凹且位似的。
+
+同时假设知情代理人在所有均衡配置中总是消费两种商品的正数量。
+
+如果 $S = 2$ 且 $u^1$ 的替代弹性始终小于一或始终大于一，那么 $p(P^1)$ 在 $\mathcal{P}$ 上是可逆的。
+
+如果 $u^1$ 是科布-道格拉斯型的（替代弹性恒等于一），那么 $p(P^1)$ 在 $\mathcal{P}$ 上是常数。
+```
+
+当 $\sigma = 1$ 时，收入效应和替代效应恰好相互抵消，因此代理人 1 对商品 1 的需求不会对关于 $\bar{a}$ 的信念变化做出反应。
+
+由于需求不变，市场出清价格也不变，价格因而不揭示内部人信号的任何信息。
+
+### CES 效用
+
+为具体起见，我们使用一个采用**常替代弹性**（CES）效用函数的简化例子
+
+$$
+u(c_1, c_2) = \bigl(c_1^{\rho} + c_2^{\rho}\bigr)^{1/\rho}, \qquad \rho \in
+(-\infty,0) \cup (0,1),
+$$
+
+其替代弹性为 $\sigma = 1/(1-\rho)$。
+
+- $\rho \to 0$：科布-道格拉斯（$\sigma = 1$）。
+- $\rho < 0$：$\sigma < 1$（互补品）。
+- $0 < \rho < 1$：$\sigma > 1$（替代品）。
+
+相关的偏导数为
+
+$$
+u_1(c_1,c_2) = \bigl(c_1^\rho + c_2^\rho\bigr)^{1/\rho - 1}\, c_1^{\rho-1},
+\qquad
+u_2(c_1,c_2) = \bigl(c_1^\rho + c_2^\rho\bigr)^{1/\rho - 1}\, c_2^{\rho-1}.
+$$
+
+这个 CES 例子只是一个说明，因为定理本身涵盖任何弹性处处大于一或处处小于一的位似效用。
+
+有了这个例子，我们就可以直接将均衡价格计算为后验的函数。
+
+### 均衡价格作为后验的函数
+
+我们将代理人 1 视为*唯一*的知情交易者，他在均衡时吸收一单位的商品 1（即 $x_1 = 1$）。
+
+令 $W_1 = w^1 + \theta^1 \pi$ 表示代理人 1 的总财富（禀赋加利润份额）。
+
+代理人 1 的预算约束因而简化为 $x_2 = W_1 - p$，均衡价格是满足一阶条件的唯一的 $p \in (0, W_1)$
+
+$$
+p \bigl[q\, u_2(a_1,\, W_1-p) + (1-q)\, u_2(a_2,\, W_1-p)\bigr]
+= q\, a_1\, u_1(a_1,\, W_1-p) + (1-q)\, a_2\, u_1(a_2,\, W_1-p).
+$$
+
+对于科布-道格拉斯效用（$\sigma = 1$），一阶条件变为 $p = W_1 - p$，得到 $p^* = W_1/2$，与后验 $q$ 无关，这证实了在科布-道格拉斯情形下没有信息通过价格传递。
+
+我们在下面数值计算一阶条件。
+
+```{code-cell} ipython3
+def ces_derivatives(c1, c2, ρ):
+    """
+    返回 CES 边际效用。
+
+    在 rho = 0 附近使用科布-道格拉斯极限。
+    """
+    if abs(ρ) < 1e-4:
+        u1 = 0.5 * np.sqrt(c2 / c1)
+        u2 = 0.5 * np.sqrt(c1 / c2)
+    else:
+        common = (c1**ρ + c2**ρ)**(1 / ρ - 1)
+        u1 = common * c1**(ρ - 1)
+        u2 = common * c2**(ρ - 1)
+    return u1, u2
+
+
+def eq_price(q, a1, a2, W1, ρ):
+    """返回后验 q 对应的均衡价格。"""
+    def residual(p):
+        x2 = W1 - p
+        u1_s1, u2_s1 = ces_derivatives(a1, x2, ρ)
+        u1_s2, u2_s2 = ces_derivatives(a2, x2, ρ)
+        lhs = p * (q * u2_s1 + (1 - q) * u2_s2)
+        rhs = q * a1 * u1_s1 + (1 - q) * a2 * u1_s2
+        return lhs - rhs
+
+    try:
+        return brentq(residual, 1e-6, W1 - 1e-6, xtol=1e-10)
+    except ValueError:
+        return np.nan
+```
+
+```{code-cell} ipython3
+---
+mystnb:
+  figure:
+    caption: 均衡价格与后验
+    name: fig-eq-price-posterior
+---
+import matplotlib as mpl  # i18n
+FONTPATH = "fonts/SourceHanSerifSC-SemiBold.otf"  # i18n
+mpl.font_manager.fontManager.addfont(FONTPATH)  # i18n
+mpl.rcParams['font.family'] = ['Source Han Serif SC']  # i18n
+
+a1, a2 = 2.0, 0.5     # 状态值 (a1 > a2)
+W1 = 4.0
+
+q_grid = np.linspace(0.05, 0.95, 200)
+
+ρ_values = [-0.5, 0.0, 0.5]
+ρ_labels = [
+    r"$\rho = -0.5$ ($\sigma = 0.67$, 互补品)",
+    r"$\rho = 0$ ($\sigma = 1$, 科布-道格拉斯)",
+    r"$\rho = 0.5$ ($\sigma = 2$, 替代品)",
+]
+
+fig, ax = plt.subplots(figsize=(8, 5))
+
+for ρ, label in zip(ρ_values, ρ_labels):
+    prices = [eq_price(q, a1, a2, W1, ρ) for q in q_grid]
+    ax.plot(q_grid, prices, label=label, lw=2)
+
+ax.set_xlabel(r"后验概率 $q = \Pr(\bar{a} = a_1)$", fontsize=12)
+ax.set_ylabel("均衡价格 $p^*(q)$", fontsize=12)
+ax.legend(fontsize=10)
+plt.tight_layout()
+plt.show()
+```
+
+该图证实了 {prf:ref}`ime_theorem_invertibility_conditions`。
+
+对于 $\sigma \neq 1$ 的 CES，均衡价格在 $q$ 上是严格单调的。
+
+因此，知道均衡映射 $p^*(\cdot)$ 的外部观察者可以唯一地反转价格以恢复 $q$，故内部信息被完全传递。
+
+对于科布-道格拉斯（$\sigma = 1$），价格在 $q$ 上是平坦的，因此信息永远不会通过市场传递。
+
+```{code-cell} ipython3
+p_cd = [eq_price(q, a1, a2, W1, ρ=0.0) for q in q_grid]
+
+print(f"Cobb-Douglas (rho=0): min p* = {min(p_cd):.6f}, "
+      f"max p* = {max(p_cd):.6f}, "
+      f"range = {max(p_cd)-min(p_cd):.2e}")
+print(f"Analytical CD price  = W1/2 = {W1/2:.6f}")
+```
+
+每一项都恰好等于 $W_1/2 = 2.0$，从解析上证实了科布-道格拉斯均衡价格与 $q$ 以及状态值 $a_1, a_2$ 无关。
+
+数值图显示了单调性，下一小节将这个模式与 {prf:ref}`ime_theorem_invertibility_conditions` 的证明联系起来。
+
+(price_monotonicity)=
+### 为什么单调性取决于 $\sigma$
+
+固定一个价格 $p$，并将 $\alpha_s(p)$ 和 $\beta_s(p)$ 视为常数。
+
+两状态一阶条件的右侧
+
+$$
+\frac{\alpha_1(p)\, q + \alpha_2(p)\, (1-q)}
+     {\beta_1(p)\, q + \beta_2(p)\, (1-q)}
+$$
+
+因而是 $q$ 单独的函数，其导数为
+
+$$
+\frac{\partial}{\partial q}
+\frac{\alpha_1 q + \alpha_2 (1-q)}
+     {\beta_1 q + \beta_2 (1-q)}
+= \frac{\alpha_1 \beta_2 - \alpha_2 \beta_1}
+       {\bigl[\beta_1 q + \beta_2 (1-q)\bigr]^2}.
+$$
+
+因此符号由 $\alpha_1 \beta_2 - \alpha_2 \beta_1$ 决定，如果这个符号是恒定的，那么对每个固定价格，最多有一个与一阶条件相容的后验权重 $q$，这正是 {prf:ref}`ime_theorem_invertibility_conditions` 所要求的。
+
+利用
+
+$$
+\frac{\alpha_s}{\beta_s}
+  = \frac{a_s\, u_1(a_s x_1, x_2)}{u_2(a_s x_1, x_2)}
+  = a_s^{(\sigma-1)/\sigma}\,\Bigl(\frac{x_2}{x_1}\Bigr)^{1/\sigma},
+$$
+
+可以证明
+
+$$
+\frac{\partial}{\partial a}\,\frac{\alpha}{\beta}
+  = \frac{(\sigma - 1)}{\sigma}\, a^{-1/\sigma}\,
+    \Bigl(\frac{x_2}{x_1}\Bigr)^{1/\sigma}.
+$$
+
+对于 CES 设定，当 $\sigma > 1$ 时该导数为正，当 $\sigma < 1$ 时为负，*当 $\sigma = 1$ 时为零*。
+
+换句话说，对于 CES 效用，比率 $\alpha_s / \beta_s$ 随状态值 $a_s$ 单调变化，除非 $\sigma = 1$，这使得固定价格的一阶条件表达式在 $q$ 上单调，进而带来可逆性。
+
+科布-道格拉斯情形下导数消失意味着边际替代率与 $a_s$ 无关，因此知情代理人的需求，进而均衡价格，不会对信念变化做出反应。
+
+让我们将比率 $\alpha_s / \beta_s$ 作为 $a_s$ 的函数，对不同的 $\sigma$ 值进行可视化：
+
+```{code-cell} ipython3
+---
+mystnb:
+  figure:
+    caption: 边际替代率
+    name: fig-mrs-alpha-beta
+---
+a_vals = np.linspace(0.3, 3.0, 300)
+x1_fix, x2_fix = 1.0, 1.0
+
+fig, ax = plt.subplots(figsize=(7, 4))
+for ρ in [-0.5, -1e-6, 0.5]:
+    σ = 1 / (1 - ρ) if abs(ρ) > 1e-8 else 1.0
+    ratios = []
+    for a in a_vals:
+        u1, u2 = ces_derivatives(a * x1_fix, x2_fix, ρ)
+        ratios.append(a * u1 / u2)
+    ax.plot(a_vals, ratios, label=rf"$\sigma = {σ:.2f}$", lw=2)
+
+ax.set_xlabel(r"状态值 $a_s$", fontsize=12)
+ax.set_ylabel(r"$\alpha_s / \beta_s = a_s u_1 / u_2$", fontsize=12)
+ax.axhline(y=1.0, color="black", lw=0.8, ls="--")
+ax.legend(fontsize=10)
+plt.tight_layout()
+plt.show()
+```
+
+当 $\sigma = 1$ 时，该比率在所有 $a_s$ 值上都是常数，因此关于状态的信息对边际替代率没有影响。
+
+对于 $\sigma < 1$，该比率在 $a_s$ 上递减，而对于 $\sigma > 1$，它递增，这使得均衡价格在两种情况下都在后验 $q$ 上严格单调。
+
+静态分析询问当前价格是否揭示当前私有信息，而下一节则询问整个价格历史随时间揭示了什么。
+
+(bayesian_price_expectations)=
+## 动态经济中的贝叶斯价格预期
+
+我们现在转向 {cite:t}`kihlstrom_mirman1975` 第 3 节所讨论的一个问题。
+
+### 一个随机交换经济
+
+时间是离散的：$t = 1, 2, \ldots$
+
+在每一期 $t$：
+
+1. 消费者 $i$ 收到一个随机禀赋 $\omega_i^t$。
+2. 市场开放；竞争价格 $p^t = p(\omega^t)$ 出清所有市场。
+3. 消费者进行交易和消费。
+
+禀赋向量 $\{\tilde{\omega}^t\}$ 是**独立同分布**的，其密度为 $f(\omega^t \mid \lambda)$，其中 $\lambda = (\lambda_1, \ldots, \lambda_K)$ 是一个**结构参数向量**（维数为 $K$），它是*固定但未知的*。
+
+$t$ 时刻的均衡价格是 $\omega^t$ 的确定性函数，因此 $\{p^t\}$ 也是独立同分布的。
+
+对于任何可测的价格集合 $P$，令
+
+$$
+W(P) = \{\omega^t : p(\omega^t) \in P\}.
+$$
+
+那么
+
+$$
+P_\lambda(p^t \in P) = P_\lambda(\omega^t \in W(P))
+= \int_{W(P)} f(\omega^t \mid \lambda)\, d\omega^t.
+$$
+
+所诱导的价格密度记为 $g(p^t \mid \lambda)$。
+
+对于给定的结构 $\lambda$，这个密度是模型的可观测含义，当几个结构隐含相同的密度时，我们将它们归为一个单一的简约形式类。
+
+因此下一个问题是观察者仅从价格数据中能够和不能够推断出关于结构的什么信息。
+
+### 识别问题
+
+由于价格观测仅识别所诱导的价格密度 $g(\cdot \mid \lambda)$，并且由于从结构到简约形式的映射 $\lambda \mapsto g(\cdot \mid \lambda)$ 可能是多对一的，因此价格数据可能只识别一个简约形式类，而不是精确的结构。
+
+特别地，即使有无限的价格数据，也可能无法从 $g(p \mid \lambda)$ 中恢复 $\lambda$。
+
+为了处理这一点，将 $\Lambda$ 划分为等价类 $\mu$，使得当对所有 $p$ 都有 $g(p \mid \lambda) = g(p \mid \lambda')$ 时，$\lambda \in \mu$ 且 $\lambda' \in \mu$。
+
+包含真实 $\lambda$ 的等价类 $\mu$ 是与价格数据相关的**简约形式**。
+
+知道无限价格历史的观察者学到了 $\mu$，但不一定学到 $\lambda$。
+
+一旦这个区别清楚了，贝叶斯更新就可以直接写出来。
+
+### 贝叶斯更新
+
+一位不知情的观察者从 $\lambda \in \Lambda$ 上的先验 $h(\lambda)$ 开始。
+
+如果观察者能够直接看到禀赋，那么后验将是
+
+$$
+h(\lambda \mid \omega^1, \ldots, \omega^t)
+  = \frac{h(\lambda)\, \prod_{\tau=1}^{t} f(\omega^\tau \mid \lambda)}
+         {\displaystyle\sum_{\lambda' \in \Lambda}
+           h(\lambda')\, \prod_{\tau=1}^{t} f(\omega^\tau \mid \lambda')},
+$$
+
+该论文诉诸于一个贝叶斯一致性结果，得出结论认为该后验集中于真实结构 $\bar \lambda$。
+
+在观察价格序列 $(p^1, \ldots, p^t)$ 之后，观察者的贝叶斯后验为
+
+$$
+h(\lambda \mid p^1, \ldots, p^t)
+  = \frac{h(\lambda)\, \prod_{\tau=1}^{t} g(p^\tau \mid \lambda)}
+         {\displaystyle\sum_{\lambda' \in \Lambda}
+           h(\lambda')\, \prod_{\tau=1}^{t} g(p^\tau \mid \lambda')}.
+$$
+
+价格数据无法区分同一简约形式类内的结构。
+
+事实上，如果 $\lambda$ 和 $\lambda'$ 属于同一类 $\mu$，那么 $g(\cdot \mid \lambda) = g(\cdot \mid \lambda')$，因此
+
+$$
+\frac{h(\lambda \mid p^1, \ldots, p^t)}
+     {h(\lambda' \mid p^1, \ldots, p^t)}
+= \frac{h(\lambda)}{h(\lambda')}
+$$
+
+对每一个样本历史都成立，因此在一个观测上等价的类内的相对几率永远不会改变。
+
+在 $t$ 时刻，观察者对下一期的价格预期为
+
+$$
+g(p^{t+1} \mid p^1, \ldots, p^t)
+  = \sum_{\lambda \in \Lambda} g(p^{t+1} \mid \lambda)\,
+    h(\lambda \mid p^1, \ldots, p^t).
+$$
+
+### 收敛定理
+
+```{prf:theorem} 贝叶斯收敛
+:label: ime_theorem_bayesian_convergence
+
+设 $\bar\lambda$ 为真实结构参数，$\bar\mu$ 为包含 $\bar\lambda$ 的简约形式。
+
+假设先验对简约形式类 $\bar\mu$ 赋予正概率。
+
+将简约形式类上的后验质量定义为
+
+$$
+H_t(\mu) = \sum_{\lambda \in \mu} h(\lambda \mid p^1, \ldots, p^t).
+$$
+
+由于类内所有结构都隐含相同的 $g(\cdot \mid \lambda)$，预测密度可以等价地写为
+
+$$
+g(p^{t+1} \mid p^1, \ldots, p^t)
+  = \sum_{\mu} g(p^{t+1} \mid \mu)\, H_t(\mu).
+$$
+
+那么
+
+$$
+\lim_{t \to \infty} H_t(\mu)
+  = \begin{cases} 1 & \text{如果 } \mu = \bar\mu, \\ 0 & \text{否则，}
+  \end{cases}
+$$
+
+以概率一成立。
+
+因此，
+
+$$
+\lim_{t \to \infty} g(p^{t+1} \mid p^1, \ldots, p^t) = g(p \mid \bar\mu),
+$$
+
+它等于一位完全知情观察者的理性预期价格分布。
+```
+
+```{note}
+注意该定理仅要求先验对包含真实结构 $\bar\lambda$ 的简约形式类 $\bar\mu$ 赋予正概率。
+
+这一点由对真实结构参数 $\bar\lambda$ 本身赋予正概率所隐含，但比后者更弱。
+
+一个先验可以对 $\bar\lambda$ 赋予零质量，同时仍然对 $\bar\mu$ 内的其他结构赋予正质量。
+```
+
+重要的区别在于价格观察者不必学到 $\bar \lambda$ 本身。
+
+他们只学到哪个简约形式类是正确的。
+
+这对于预测就足够了，因为每个 $\lambda \in \bar \mu$ 都产生相同的价格密度 $g(\cdot \mid \bar \mu)$。
+
+理性价格预期源于学到简约形式，而非识别经济的每一个结构细节。
+
+这里"理性预期"意味着观察者对下一期价格的预测分布与真实简约形式所产生的客观价格分布相匹配。
+
+现在让我们转向一个简单的模拟。
+
+(bayesian_simulation)=
+## 从价格中模拟贝叶斯学习
+
+我们用一个两状态例子来说明该定理。
+
+两个可能的简约形式 $\mu_1$ 和 $\mu_2$ 分别产生价格 $p^t \sim N(\bar{p}_i, \sigma_p^2)$，其中 $i = 1, 2$。
+
+观察者知道这两个可能的价格分布（简约形式），但不知道哪一个支配着数据。
+
+这是一个我们在 {doc}`likelihood_bayes` 中见过的**贝叶斯模型选择**问题。
+
+给定 $\mu_1$ 上的先验 $h_0$ 和观测到的价格 $p^t$，在第 $t$ 期之后 $\mu_1$ 上的后验权重为
+
+$$
+h_t = \frac{h_{t-1}\, g(p^t \mid \mu_1)}{h_{t-1}\, g(p^t \mid \mu_1)
+      + (1-h_{t-1})\, g(p^t \mid \mu_2)}.
+$$
+
+我们考虑一个具有两个不同均值的正态分布的数值例子
+
+```{code-cell} ipython3
+def simulate_bayesian_learning(
+    p_bar_true, p_bar_alt, σ_p, T, h0, n_paths, seed=42
+):
+    """在两个高斯简约形式之间模拟后验学习。"""
+    rng = np.random.default_rng(seed)
+    h_paths = np.zeros((n_paths, T + 1))
+    h_paths[:, 0] = h0
+
+    for path in range(n_paths):
+        h = h0
+        prices = rng.normal(p_bar_true, σ_p, size=T)
+        for t, p in enumerate(prices):
+            g_true = norm.pdf(p, loc=p_bar_true, scale=σ_p)
+            g_alt = norm.pdf(p, loc=p_bar_alt, scale=σ_p)
+            denom = h * g_true + (1 - h) * g_alt
+            h = h * g_true / denom
+            h_paths[path, t + 1] = h
+
+    return h_paths
+
+
+def plot_bayesian_learning(h_paths, p_bar_true, p_bar_alt, ax):
+    """绘制随时间变化的后验信念。"""
+    T = h_paths.shape[1] - 1
+    t_grid = np.arange(T + 1)
+
+    for path in h_paths:
+        ax.plot(t_grid, path, alpha=0.25, lw=0.8, color="steelblue")
+
+    median_path = np.median(h_paths, axis=0)
+    ax.plot(t_grid, median_path, color="navy", lw=2, label="后验中位数")
+
+    ax.axhline(
+        y=1.0,
+        color="black",
+        ls="--",
+        lw=1.2,
+        label="真实模型权重 = 1",
+    )
+    ax.set_xlabel("时期 $t$", fontsize=12)
+    ax.set_ylabel(r"$h_t$ = 真实模型上的后验权重", fontsize=12)
+    ax.legend(fontsize=10)
+```
+
+我们考虑两种情形，一种容易学习，另一种较难学习，使用 $T = 300$ 个时期、$n = 40$ 条模拟路径、一个扩散先验 $h_0 = 0.5$，以及共同的标准差 $\sigma_p = 0.4$。
+
+- *容易的情形*：真实模型 $N(2.0,\, 0.4^2)$，备择模型 $N(1.2,\, 0.4^2)$。
+- *困难的情形*：真实模型 $N(2.0,\, 0.4^2)$，备择模型 $N(1.8,\, 0.4^2)$。
+
+学习是容易还是困难取决于真实分布与备择假设相比"有多接近"。
+
+```{code-cell} ipython3
+---
+mystnb:
+  figure:
+    caption: 跨路径的贝叶斯学习
+    name: fig-bayesian-learning
+---
+T = 300
+h0 = 0.5     # 扩散先验
+n_paths = 40
+σ_p = 0.4
+
+fig, axes = plt.subplots(1, 2, figsize=(12, 5))
+
+# 不同的简约形式
+p_bar_true, p_bar_alt = 2.0, 1.2
+h_paths = simulate_bayesian_learning(p_bar_true, p_bar_alt, σ_p, T, h0, n_paths)
+plot_bayesian_learning(h_paths, p_bar_true, p_bar_alt, axes[0])
+
+# 相似的简约形式
+p_bar_true, p_bar_alt = 2.0, 1.8
+h_paths_hard = simulate_bayesian_learning(
+    p_bar_true, p_bar_alt, σ_p, T, h0, n_paths
+)
+plot_bayesian_learning(h_paths_hard, p_bar_true, p_bar_alt, axes[1])
+
+plt.tight_layout()
+plt.show()
+```
+
+在两个面板中，真实模型上的后验权重都以概率一收敛到 1，尽管当两个价格分布相似时（右面板）收敛较慢。
+
+### 价格预期 vs. 理性预期
+
+我们现在验证观察者的价格预期收敛到理性预期分布 $g(p \mid \bar\mu)$。
+
+我们使用上面"难以学习"例子的参数化（$\bar{p}_{\text{true}} = 2.0$，$\bar{p}_{\text{alt}} = 1.8$，$\sigma_p = 0.4$），扩展到 $T = 1{,}000$ 个时期，使用单条模拟路径和先验 $h_0 = 0.5$
+
+```{code-cell} ipython3
+---
+mystnb:
+  figure:
+    caption: 价格分布收敛
+    name: fig-price-convergence
+---
+def price_expectation(h_t, p_bar_true, p_bar_alt, σ_p, p_grid):
+    """返回后验权重 h_t 处的预测价格密度。"""
+    return (
+        h_t * norm.pdf(p_grid, loc=p_bar_true, scale=σ_p)
+        + (1 - h_t) * norm.pdf(p_grid, loc=p_bar_alt, scale=σ_p)
+    )
+
+
+p_bar_true, p_bar_alt = 2.0, 1.8
+σ_p = 0.4
+n_paths = 1
+T_long = 1000
+
+h_paths_long = simulate_bayesian_learning(
+    p_bar_true, p_bar_alt, σ_p, T_long, h0=0.5, n_paths=n_paths, seed=7
+)
+
+p_grid = np.linspace(0.0, 3.5, 300)
+re_density = norm.pdf(p_grid, loc=p_bar_true, scale=σ_p)
+
+fig, ax = plt.subplots(figsize=(8, 5))
+snapshots = [0, 25, 100, 300, 1000]
+palette   = plt.cm.Blues(np.linspace(0.3, 1.0, len(snapshots)))
+
+for t_snap, col in zip(snapshots, palette):
+    h_t = h_paths_long[0, t_snap]
+    dens = price_expectation(h_t, p_bar_true, p_bar_alt, σ_p, p_grid)
+    ax.plot(
+        p_grid,
+        dens,
+        color=col,
+        lw=2,
+        label=rf"$t = {t_snap}$, $h_t = {h_t:.3f}$",
+    )
+
+ax.plot(p_grid, re_density, "k--", lw=2,
+        label=r"理性预期 $g(p \mid \bar{\mu})$")
+ax.set_xlabel("价格 $p$", fontsize=12)
+ax.set_ylabel("密度", fontsize=12)
+ax.legend(fontsize=9)
+plt.tight_layout()
+plt.show()
+```
+
+预测密度序列（蓝色的深浅）随着经验的累积收敛到理性预期密度（黑色虚线）。
+
+这说明了 {prf:ref}`ime_theorem_bayesian_convergence`。
+
+我们现在可以通过考察一个学到了简约形式但没有学到底层结构的例子来使这一点更加尖锐。
+
+(km_extension_nonidentification)=
+### 学到简约形式而不识别结构
+
+这个收敛结果特别引人注目，因为即使底层**结构** $\lambda$ *无法*由价格*识别*，观察者也会收敛到*理性预期*。
+
+为了说明这一点，考虑一个有*三个*可能结构 $\lambda^{(1)}, \lambda^{(2)}, \lambda^{(3)}$ 但只有*两个*简约形式 $\mu_1 = \{\lambda^{(1)}, \lambda^{(2)}\}$ 和 $\mu_2 = \{\lambda^{(3)}\}$ 的情形（因为 $\lambda^{(1)}$ 和 $\lambda^{(2)}$ 产生相同的价格分布）。
+
+我们继续使用难以学习的参数化，因此三个结构的价格均值为 $\bar{p}_1 = \bar{p}_2 = 2.0$ 和 $\bar{p}_3 = 1.8$，共同标准差 $\sigma_p = 0.4$，均匀先验 $h_0 = (1/3, 1/3, 1/3)$，以及 $30$ 条路径上的 $T = 400$ 个时期。
+
+真实结构是 $\lambda^{(1)}$。
+
+```{code-cell} ipython3
+---
+mystnb:
+  figure:
+    caption: 非识别情况下的学习
+    name: fig-nonidentification
+---
+def simulate_learning_3struct(
+    T, h0_vec, p_bar_vec, σ_p, true_idx, n_paths, seed=0
+):
+    """模拟具有三个结构和两个简约形式的学习。"""
+    rng = np.random.default_rng(seed)
+    h_paths = np.zeros((n_paths, T + 1, 3))
+    h_paths[:, 0, :] = h0_vec
+
+    for path in range(n_paths):
+        h = np.array(h0_vec, dtype=float)
+        prices = rng.normal(p_bar_vec[true_idx], σ_p, size=T)
+        for t, p in enumerate(prices):
+            likelihoods = norm.pdf(p, loc=p_bar_vec, scale=σ_p)
+            h = h * likelihoods
+            h /= h.sum()
+            h_paths[path, t + 1, :] = h
+
+    return h_paths
+
+
+# 结构 0 和 1 共享相同的简约形式
+p_bar_vec = np.array([2.0, 2.0, 1.8])
+h0_vec = np.array([1 / 3, 1 / 3, 1 / 3])
+σ_p = 0.4
+T = 400
+true_idx = 0     # 结构 0 与结构 1 在观测上等价
+
+h_paths_3 = simulate_learning_3struct(
+    T, h0_vec, p_bar_vec, σ_p, true_idx, n_paths=30
+)
+t_grid = np.arange(T + 1)
+
+fig, axes = plt.subplots(1, 3, figsize=(13, 4), sharey=True)
+struct_labels = [
+    r"$\lambda^{(1)}$",
+    r"$\lambda^{(2)}$",
+    r"$\lambda^{(3)}$",
+]
+
+for k, (ax, label) in enumerate(zip(axes, struct_labels)):
+    for path in h_paths_3:
+        ax.plot(t_grid, path[:, k], alpha=0.25, lw=0.8, color="steelblue")
+    ax.plot(t_grid, np.median(h_paths_3[:, :, k], axis=0),
+            color="navy", lw=2, label=f"{label} 上的中位数权重")
+    ax.set_xlabel("时期 $t$", fontsize=11)
+    ax.legend(fontsize=9)
+
+axes[0].set_ylabel("后验权重", fontsize=11)
+plt.tight_layout()
+plt.show()
+```
+
+观察者以概率一正确地排除了 $\lambda^{(3)}$（错误的简约形式），但无法区分 $\lambda^{(1)}$ 和 $\lambda^{(2)}$，因为它们产生相同的价格分布。
+
+尽管如此，观察者的**价格预期**收敛到理性预期，因为两个结构都隐含相同的简约形式 $\bar\mu$。
+
+
+## 练习
+
+```{exercise}
+:label: km_ex1
+
+**CARA 投资组合效用与股票市场解释。**
+
+考虑一个两状态经济（$a_1 = 2$，$a_2 = 0.5$），其中知情代理人对投资组合财富具有 **CARA**（常绝对风险厌恶）偏好：
+
+$$
+u(W) = -e^{-\gamma W}, \quad W = x_2 + \bar{a}\, x_1.
+$$
+
+代理人选择 $x_1$ 以最大化
+
+$$
+q\,u(W_1) + (1-q)\,u(W_2), \quad W_s = w - p\,x_1 + a_s\,x_1,
+$$
+
+受预算约束 $p\,x_1 + x_2 = w$ 的约束。
+
+商品 1 的总供给为 $X_1 = 1$。
+
+1. 推导知情代理人最优 $x_1$ 的一阶条件。
+
+1. 使用市场出清条件 $x_1 = 1$（知情代理人吸收全部供给）来得到均衡价格 $p^*(q)$ 的一个隐式方程，并对 $q \in (0,1)$ 和若干 $\gamma$ 值进行数值求解。
+
+1. *解析地*证明 $p^*(q)$ 具有闭式解
+
+   $$
+   p^*(q) = \frac{a_2 + R(q,\gamma)\, a_1}{1 + R(q,\gamma)},
+   \qquad R(q,\gamma) = \frac{q}{1-q}\, e^{-\gamma(a_1-a_2)},
+   $$
+
+   并验证 $p^*(q)$ 在 $q$ 上是严格递增的。
+```
+
+```{solution-start} km_ex1
+:class: dropdown
+```
+
+对于一阶条件，定义 $W_s = w + (a_s - p)\,x_1$，其中 $s = 1, 2$。
+
+那么 FOC 为
+
+$$
+q\,(a_1 - p)\,\gamma\, e^{-\gamma W_1}
+= (1-q)\,(p - a_2)\,\gamma\, e^{-\gamma W_2},
+$$
+
+或等价地（除以 $\gamma$ 并重新排列）
+
+$$
+q\,(a_1 - p)\, e^{-\gamma(a_1-p) x_1}
+  = (1-q)\,(p - a_2)\, e^{\gamma(p-a_2) x_1}.
+$$
+
+设 $x_1 = 1$（知情代理人吸收全部供给），这变成关于 $p$ 的标量求根问题：
+
+$$
+F(p;\,q,\gamma) \equiv
+  q\,(a_1-p)\,e^{-\gamma(a_1-p)} - (1-q)\,(p-a_2)\,e^{\gamma(p-a_2)} = 0.
+$$
+
+```{code-cell} ipython3
+from scipy.optimize import brentq
+
+def F_cara(p, q, a1, a2, γ, x1=1.0):
+    """CARA 均衡条件的残差。"""
+    return (q * (a1 - p) * np.exp(-γ * (a1 - p) * x1)
+            - (1 - q) * (p - a2) * np.exp(γ * (p - a2) * x1))
+
+a1, a2 = 2.0, 0.5
+q_grid = np.linspace(0.05, 0.95, 200)
+γ_values = [0.5, 1.0, 2.0, 5.0]
+colors_sol = plt.cm.plasma(np.linspace(0.15, 0.85, len(γ_values)))
+
+fig, ax = plt.subplots(figsize=(8, 5))
+for γ, color in zip(γ_values, colors_sol):
+    p_eq = [brentq(F_cara, a2, a1,
+                   args=(q, a1, a2, γ))
+            for q in q_grid]
+    ax.plot(q_grid, p_eq, lw=2, color=color,
+            label=rf"$\gamma = {γ}$")
+
+ax.set_xlabel(r"后验 $q = \Pr(\bar a = a_1)$", fontsize=12)
+ax.set_ylabel("均衡价格 $p^*(q)$", fontsize=12)
+ax.set_title("CARA 偏好：均衡价格", fontsize=12)
+ax.legend(fontsize=10)
+plt.tight_layout()
+plt.show()
+```
+
+对于每个 $\gamma > 0$，价格在 $q$ 上都是严格递增的。
+
+对于闭式解，从 $x_1 = 1$ 处的 FOC 出发，两边除以 $(a_1 - p)(p - a_2)$，并合并指数项：
+
+$$
+\frac{q\,(a_1 - p)}{(1-q)\,(p - a_2)} = e^{\gamma(a_1 - a_2)}.
+$$
+
+重新排列得到
+
+$$
+\frac{p - a_2}{a_1 - p} = \frac{q}{1-q}\, e^{-\gamma(a_1 - a_2)}
+\equiv R(q,\gamma),
+$$
+
+求解所得的关于 $p$ 的线性方程得到
+
+$$
+p^*(q) = \frac{a_2 + R(q,\gamma)\, a_1}{1 + R(q,\gamma)}.
+$$
+
+由于 $R(q,\gamma)$ 在 $q$ 上严格递增，且 $dp^*/dR = (a_1 - a_2)/(1 + R)^2 > 0$，因此均衡价格 $p^*(q)$ 在 $q$ 上严格递增。
+
+这个练习使用了 {cite:t}`kihlstrom_mirman1975` 所强调的股票市场解释。
+
+投资组合财富为 $W = x_2 + \bar{a}\, x_1$，因此 $a x_1$ 和 $x_2$ 在每个状态中是完全替代品。
+
+因此 $u(a x_1, x_2)$ 两个参数之间的替代弹性是无穷大，对应于 {prf:ref}`ime_theorem_invertibility_conditions` 中 $\sigma > 1$ 的一侧。
+
+不同之处在于，这个例子不是该定理所分析的完整均衡模型，而是一个具有单一知情代理人和固定风险资产供给的局部均衡模型。
+
+```{solution-end}
+```
+
+```{exercise}
+:label: km_ex2
+
+在贝叶斯学习模拟中，收敛到理性预期的速度由两个简约形式之间的 **Kullback-Leibler 散度**决定。
+
+对于两个均值为 $\bar{p}_1$ 和 $\bar{p}_2$ 且共同方差为 $\sigma_p^2$ 的正态分布，从 $g(\cdot \mid \mu_1)$ 到 $g(\cdot \mid \mu_2)$ 的 KL 散度 $D_{KL}(\mu_1 \| \mu_2)$ 为
+
+$$
+D_{KL}(\mu_1 \| \mu_2) = \frac{(\bar{p}_1 - \bar{p}_2)^2}{2\sigma_p^2},
+$$
+
+在方差相等的情况下，它关于两个均值是对称的。
+
+1. 对于"容易的"情形（$\bar{p}_1 = 2.0$，$\bar{p}_2 = 1.2$）和"困难的"情形（$\bar{p}_1 = 2.0$，$\bar{p}_2 = 1.8$），计算 $\sigma_p = 0.4$ 时的 $D_{KL}$。
+
+1. 用 $n=100$ 条路径重新运行本讲中两种情形的模拟。对每条路径计算 $h_t \geq 0.99$ 的第一个时期 $T_{0.99}$。绘制两种情形下 $T_{0.99}$ 的直方图。
+
+1. 中位数 $T_{0.99}$ 如何随 $D_{KL}$ 缩放？数值验证对于某个常数 $C$，大致有 $T_{0.99} \approx C / D_{KL}$。
+```
+
+```{solution-start} km_ex2
+:class: dropdown
+```
+
+这是一个解法：
+
+```{code-cell} ipython3
+σ_p = 0.4
+
+def kl_normal(p1, p2, σ):
+    """返回 N(p1, σ^2) 和 N(p2, σ^2) 的 KL 散度。"""
+    return (p1 - p2)**2 / (2 * σ**2)
+
+cases = [("Easy",  2.0, 1.2), ("Hard", 2.0, 1.8)]
+for name, p1, p2 in cases:
+    kl = kl_normal(p1, p2, σ_p)
+    print(f"{name} case: D_KL = {kl:.4f}")
+
+n_paths = 100
+
+fig, axes = plt.subplots(1, 2, figsize=(11, 4))
+for ax, (name, p1, p2) in zip(axes, cases):
+    kl = kl_normal(p1, p2, σ_p)
+    paths = simulate_bayesian_learning(p1, p2, σ_p, T=2000,
+                                       h0=0.5, n_paths=n_paths, seed=42)
+    # 后验 >= 0.99 的第一个时期
+    T99 = []
+    for path in paths:
+        idx = np.where(path >= 0.99)[0]
+        T99.append(idx[0] if len(idx) > 0 else 2001)
+
+    median_T = np.median(T99)
+    ax.hist(T99, bins=20, color="steelblue", edgecolor="white", alpha=0.8)
+    ax.axvline(median_T, color="crimson", lw=2,
+               label=fr"中位数 $T_{{0.99}} = {median_T:.0f}$")
+    ax.set_title(
+        f"{name}: $D_{{KL}} = {kl:.4f}$,  "
+        fr"$\widehat C = T_{{0.99}} D_{{KL}} \approx {median_T * kl:.1f}$",
+        fontsize=11 
+    )
+    ax.set_xlabel(r"$T_{0.99}$", fontsize=12)
+    ax.set_ylabel("计数", fontsize=11)
+    ax.legend(fontsize=10)
+
+plt.tight_layout()
+plt.show()
+```
+
+中位数 $T_{0.99}$ 大致按 $C/D_{KL}$ 缩放，证实了当两个简约形式更容易区分时（大的 $D_{KL}$）学习更快。
+
+```{solution-end}
+```
+
+```{exercise}
+:label: km_ex3
+
+{prf:ref}`ime_theorem_bayesian_convergence` 要求先验对真实简约形式类 $\bar\mu$ 赋予正概率，等价地对某个产生真实价格分布 $g(\cdot \mid \bar\mu)$ 的结构赋予正概率。
+
+在这个练习中，真实简约形式本身被排除在先验支持之外，因此我们研究当先验中没有模型产生真实价格分布时会发生什么。
+
+从 $N(2.0, 0.4^2)$ 模拟 $T = 1,000$ 个时期的价格，但使用一个对两个*错误*模型 $N(1.5, 0.4^2)$ 和 $N(2.3, 0.4^2)$ 赋予相等权重的先验。
+
+绘制每个模型随时间变化的后验权重。
+
+讨论你的发现。
+```
+
+```{solution-start} km_ex3
+:class: dropdown
+```
+
+这是一个解法：
+
+```{code-cell} ipython3
+def simulate_misspecified(
+    T, p_bar_true, p_bar_wrong, σ_p, h0, n_paths, seed=0
+):
+    """在错误设定的双模型先验下模拟学习。"""
+    rng = np.random.default_rng(seed)
+    h_paths = np.zeros((n_paths, T + 1, 2))
+    h_paths[:, 0, :] = h0
+
+    for path in range(n_paths):
+        h = np.array(h0, dtype=float)
+        prices = rng.normal(p_bar_true, σ_p, size=T)
+        for t, price in enumerate(prices):
+            likes = norm.pdf(price, loc=p_bar_wrong, scale=σ_p)
+            h = h * likes
+            h /= h.sum()
+            h_paths[path, t + 1, :] = h
+
+    return h_paths
+
+
+def predictive_density(weights, means, σ_p, p_grid):
+    """返回当前后验权重下的预测密度。"""
+    density = np.zeros_like(p_grid)
+    for weight, mean in zip(weights, means):
+        density += weight * norm.pdf(p_grid, loc=mean, scale=σ_p)
+    return density
+
+
+T = 1000
+p_true = 2.0
+p_wrong = np.array([1.5, 2.3])
+σ_p = 0.4
+h0 = np.array([0.5, 0.5])
+n_paths = 30
+
+h_misspec = simulate_misspecified(T, p_true, p_wrong, σ_p, h0, n_paths)
+
+kl_vals = (p_true - p_wrong)**2 / (2 * σ_p**2)
+for mean, kl in zip(p_wrong, kl_vals):
+    print(f"KL(true || N({mean:.1f}, σ^2)) = {kl:.4f}")
+
+t_grid = np.arange(T + 1)
+fig, axes = plt.subplots(1, 2, figsize=(12, 4))
+
+labels = [r"$N(1.5, \sigma^2)$", r"$N(2.3, \sigma^2)$"]
+for ax, k, label in zip(axes, [0, 1], labels):
+    for path in h_misspec:
+        ax.plot(t_grid, path[:, k], alpha=0.2, lw=0.8, color="steelblue")
+    ax.plot(t_grid, np.median(h_misspec[:, :, k], axis=0),
+            color="navy", lw=2, label="中位数")
+    ax.set_title(f"{label} 上的后验权重", fontsize=11)
+    ax.set_xlabel("时期 $t$", fontsize=11)
+    ax.set_ylabel("后验权重", fontsize=11)
+    ax.legend(fontsize=9)
+
+plt.tight_layout()
+plt.show()
+
+# 沿后验中位数路径的预测密度和均值
+median_path = np.median(h_misspec, axis=0)
+p_grid = np.linspace(0.0, 3.5, 300)
+closer_idx = np.argmin(kl_vals)
+
+fig, ax = plt.subplots(figsize=(8, 4))
+colors = plt.cm.Blues(np.linspace(0.3, 1.0, 4))
+for t_snap, color in zip([0, 10, 100, T], colors):
+    dens = predictive_density(median_path[t_snap], p_wrong, σ_p, p_grid)
+    ax.plot(p_grid, dens, color=color, lw=2, label=f"t = {t_snap}")
+
+ax.plot(
+    p_grid,
+    norm.pdf(p_grid, loc=p_wrong[closer_idx], scale=σ_p),
+    "k--",
+    lw=2,
+    label="KL 最优错误模型",
+)
+ax.set_xlabel("价格 $p$", fontsize=11)
+ax.set_ylabel("密度", fontsize=11)
+ax.legend(fontsize=9)
+plt.tight_layout()
+plt.show()
+
+pred_mean = np.median(
+    h_misspec[:, :, 0] * p_wrong[0] + h_misspec[:, :, 1] * p_wrong[1], axis=0
+)
+print(f"True mean: {p_true}")
+print(f"Predictive mean at T={T}: {pred_mean[-1]:.4f}")
+print(f"Closer misspecified mean: {p_wrong[np.argmin(kl_vals)]:.1f}")
+```
+
+这里
+
+$$
+D_{KL}\bigl(N(2.0, 0.4^2)\,\|\,N(2.3, 0.4^2)\bigr)
+<
+D_{KL}\bigl(N(2.0, 0.4^2)\,\|\,N(1.5, 0.4^2)\bigr),
+$$
+
+因此均值为 $2.3$ 的模型是两个错误模型中 KL 最优的近似，在模拟中后验权重集中于该模型。
+
+后验几率是累积的{doc}`似然比 <likelihood_bayes>`。
+
+如果我们比较两个错误的高斯模型 $f$ 和 $g$，那么在真实分布 $h$ 下，平均对数似然比满足
+
+$$
+\frac{1}{t} E_h[\log L_t] = K(h,g) - K(h,f).
+$$
+
+因此，如果 $f$ 在 KL 意义上比 $g$ 更接近 $h$，那么 $\log L_t$ 有正的漂移，后验几率会倾向于 $f$。
+
+```{solution-end}
+```

--- a/lectures/merging_of_opinions.md
+++ b/lectures/merging_of_opinions.md
@@ -1,0 +1,1343 @@
+---
+jupytext:
+  text_representation:
+    extension: .md
+    format_name: myst
+    format_version: 0.13
+    jupytext_version: 1.16.4
+kernelspec:
+  display_name: Python 3 (ipykernel)
+  language: python
+  name: python3
+translation:
+  title: 观点的融合：布莱克韦尔-杜宾斯定理
+  headings:
+    Overview: 概述
+    Probability measures on sequence spaces: 序列空间上的概率测度
+    Probability measures on sequence spaces::The sequence space and its filtration: 序列空间及其滤流
+    Probability measures on sequence spaces::Absolute continuity: 绝对连续性
+    Probability measures on sequence spaces::Total variation distance: 全变差距离
+    Probability measures on sequence spaces::The merging question: 融合问题
+    The likelihood-ratio martingale: 似然比鞅
+    The likelihood-ratio martingale::The likelihood ratio: 似然比
+    The likelihood-ratio martingale::Connecting conditional measures to the likelihood ratio: 将条件测度与似然比联系起来
+    The Blackwell–Dubins theorem: 布莱克韦尔-杜宾斯定理
+    The Beta–Bernoulli model: 贝塔-伯努利模型
+    The Beta–Bernoulli model::Model: 模型
+    The Beta–Bernoulli model::The marginal likelihood and likelihood ratio: 边缘似然与似然比
+    The Beta–Bernoulli model::The exact Blackwell–Dubins distance: 精确的布莱克韦尔-杜宾斯距离
+    The Beta–Bernoulli model::Simulation: 模拟
+    The Beta–Bernoulli model::Almost-sure convergence across many paths: 跨多条路径的几乎必然收敛
+    The Beta–Bernoulli model::The supermartingale property of $d_n$: $d_n$ 的上鞅性质
+    'Failure of merging: mutual singularity': 融合的失败：相互奇异
+    'Failure of merging: mutual singularity::Point-mass priors': 点质量先验
+    'Kakutani''s theorem: when does merging hold?': 角谷定理：融合何时成立？
+    'Kakutani''s theorem: when does merging hold?::Hellinger affinities': 海林格亲和度
+    'Kakutani''s theorem: when does merging hold?::Kakutani''s dichotomy': 角谷二分法
+    'Kakutani''s theorem: when does merging hold?::Implication for merging': 对融合的蕴含
+    'Kakutani''s theorem: when does merging hold?::A Gaussian product-measure example': 一个高斯乘积测度例子
+    Extension to continuous time: 推广到连续时间
+    Extension to continuous time::Girsanov's theorem and the likelihood-ratio process: 吉尔萨诺夫定理与似然比过程
+    Extension to continuous time::The dichotomy at infinity: 无穷远处的二分法
+    Applications: 应用
+    Applications::Bayesian learning: 贝叶斯学习
+    Applications::Rational expectations and heterogeneous priors: 理性预期与异质先验
+    Applications::Ergodic Markov chains: 遍历马尔可夫链
+    The rate of merging: 融合的速率
+    Summary and extensions: 总结与推广
+    Summary and extensions::Applications in economics: 经济学中的应用
+    Summary and extensions::A companion result from probability: 一个来自概率论的配套结果
+---
+
+(merging_of_opinions)=
+```{raw} jupyter
+<div id="qe-notebook-header" align="right" style="text-align:right;">
+        <a href="https://quantecon.org/" title="quantecon.org">
+                <img style="width:250px;display:inline;" width="250px" src="https://assets.quantecon.org/img/qe-menubar-logo.svg" alt="QuantEcon">
+        </a>
+</div>
+```
+
+# 观点的融合：布莱克韦尔-杜宾斯定理
+
+```{contents} Contents
+:depth: 2
+```
+
+## 概述
+
+本讲座研究 {cite:t}`blackwell1962` 的观点融合定理。
+
+该定理提出了一个简单的问题：
+
+> 如果两个主体对某个随机过程持有不同的先验信念，但无限期地观察相同的数据流，他们的概率评估最终会收敛吗？
+
+在绝对连续性条件下，答案是肯定的。
+
+如果 $Q \ll P$（即 $P$ 支配 $Q$），那么在 $P$ 和 $Q$ 下关于整个未来路径的条件分布会在全变差意义下融合，$Q$-几乎必然。
+
+如果此外还有 $P \ll Q$（因而 $P \sim Q$），那么同样的结论在两个主体的概率下都成立。
+
+这个结果与其他若干思想相关联：
+
+- 贝叶斯一致性：当先验位于正确的绝对连续性类中时，后验预测趋近于真值（{doc}`likelihood_bayes`）。
+- 一致性结果：即使主体从不同的先验出发，共同的数据也能消除分歧（{cite:t}`aumann1976`）。
+- 角谷二分法：对于乘积测度，等价性与奇异性可以从一个海林格准则中读出。
+
+我们在离散时间中展开理论，然后勾勒连续时间的类比。
+
+在整个讨论中，我们使用贝塔-伯努利模型作为贯穿始终的例子。
+
+两个主体观察相同的抛硬币结果流，但从关于硬币偏差的不同先验出发。
+
+让我们从一些导入开始。
+
+```{code-cell} ipython3
+import numpy as np
+import matplotlib.pyplot as plt
+from scipy.stats import beta as beta_dist
+from scipy.special import betaln
+import matplotlib as mpl  # i18n
+FONTPATH = "fonts/SourceHanSerifSC-SemiBold.otf"  # i18n
+mpl.font_manager.fontManager.addfont(FONTPATH)  # i18n
+mpl.rcParams['font.family'] = ['Source Han Serif SC']  # i18n
+```
+
+
+## 序列空间上的概率测度
+
+### 序列空间及其滤流
+
+设 $(S, \mathscr{S})$ 是一个标准博雷尔空间（即与完备可分度量空间的一个博雷尔子集同构的可测空间），称为信号空间。
+
+标准博雷尔假设保证了正则条件分布的存在性，这正是该定理所要求的。
+
+令 $\Omega = S^{\mathbb{N}}$，即所有无限序列
+$\omega = (x_1, x_2, \ldots)$（其中 $x_n \in S$）的集合，配备乘积
+$\sigma$-代数 $\mathscr{F} = \mathscr{S}^{\otimes \mathbb{N}}$。
+
+对于每个 $n \geq 1$，定义**有限视界** $\sigma$-代数
+
+$$
+\mathscr{F}_n = \sigma(x_1, \ldots, x_n),
+$$
+
+因此 $\mathscr{F}_1 \subseteq \mathscr{F}_2 \subseteq \cdots \subseteq \mathscr{F}$。
+
+定义**尾 $\sigma$-代数** $\mathscr{F}_\infty = \sigma\!\left(\bigcup_{n \geq 1} \mathscr{F}_n\right)$，它编码了最终能够学到的一切。
+
+集合 $\{\mathscr{F}_n\}_{n \geq 1}$ 是由观察过程生成的**自然滤流**；$\mathscr{F}_n$ 编码了从前 $n$ 个数据点能够学到的一切。
+
+设 $P$ 和 $Q$ 表示 $(\Omega, \mathscr{F})$ 上的两个概率测度。
+
+记 $P_n = P|_{\mathscr{F}_n}$ 和 $Q_n = Q|_{\mathscr{F}_n}$ 表示它们
+限制到时刻 $n$ 之前的历史。
+
+### 绝对连续性
+
+```{prf:definition} 绝对连续性
+:label: absolute_continuity
+
+$P$ 关于 $Q$ **绝对连续**，记为 $P \ll Q$，如果对于每个 $A \in \mathscr{F}$，
+$Q(A) = 0$ 蕴含 $P(A) = 0$。
+
+它们**相互绝对连续**，或**等价**，记为 $P \sim Q$，
+如果 $P \ll Q$ 和 $Q \ll P$ 都成立。
+
+$P$ 关于 $Q$ **局部绝对连续**，如果对于每个 $n \geq 1$，$P_n \ll Q_n$。
+```
+
+全局绝对连续性 $P \ll Q$ 蕴含局部绝对连续性，但
+反之不然。
+
+相互绝对连续意味着两个主体在哪些事件是*可能的*这一点上意见一致。
+
+他们可以对概率有不同看法，但都不会排除对方认为可能的事件。
+
+### 全变差距离
+
+```{prf:definition} 全变差距离
+:label: total_variation_distance
+
+对于 $(E, \mathscr{E})$ 上的两个概率测度 $\mu$ 和 $\nu$，
+
+$$
+\|\mu - \nu\|_{\mathrm{TV}}
+= \sup_{A \in \mathscr{E}} |\mu(A) - \nu(A)|
+= \frac{1}{2} \int_E \left|\frac{d\mu}{d\lambda} - \frac{d\nu}{d\lambda}\right| d\lambda,
+$$
+
+其中 $\lambda$ 是任意**支配测度**，即 $\mu \ll \lambda$ 且 $\nu \ll \lambda$（例如 $\lambda = \mu + \nu$）。
+
+等价地，$\|\mu - \nu\|_{\mathrm{TV}} \in [0,1]$，其中 0 表示 $\mu = \nu$，1 表示 $\mu \perp \nu$（相互奇异）。
+```
+
+当 $\mu \ll \nu$ 且 $f = d\mu/d\nu$ 时，
+
+$$
+\|\mu - \nu\|_{\mathrm{TV}} = \mathbb{E}_\nu[(f-1)^+] = 1 - \mathbb{E}_\nu[\min(f,1)].
+$$
+
+```{exercise}
+:label: tv_derivation
+
+证明上述恒等式。
+
+*提示：*从 $\|\mu - \nu\|_{\mathrm{TV}} = \tfrac{1}{2}\,\mathbb{E}_\nu[|f - 1|]$（这由取 $\nu$ 作为支配测度得出）出发，并利用 $\mathbb{E}_\nu[f] = 1$ 这一事实。
+```
+
+```{solution} tv_derivation
+:class: dropdown
+
+由于 $\mu \ll \nu$，我们可以取 $\nu$ 作为支配测度，因此 $d\mu/d\nu = f$ 且 $d\nu/d\nu = 1$，给出
+
+$$
+\|\mu - \nu\|_{\mathrm{TV}} = \tfrac{1}{2}\,\mathbb{E}_\nu[|f - 1|].
+$$
+
+写出 $|f-1| = (f-1)^+ + (1-f)^+$。
+
+由于 $\mu$ 是概率测度，$\mathbb{E}_\nu[f] = 1$，因此两部分贡献相等：$\mathbb{E}_\nu[(f-1)^+] = \mathbb{E}_\nu[(1-f)^+]$。
+
+因此 $\tfrac{1}{2}\,\mathbb{E}_\nu[|f-1|] = \mathbb{E}_\nu[(f-1)^+]$。
+
+接下来，注意 $(f-1)^+ = f - \min(f,1)$，所以 $\mathbb{E}_\nu[(f-1)^+] = \mathbb{E}_\nu[f] - \mathbb{E}_\nu[\min(f,1)] = 1 - \mathbb{E}_\nu[\min(f,1)]$。
+```
+
+全变差是概率测度之间距离的最强的标准概念之一。
+
+如果两个测度在全变差意义下接近，那么它们对每个事件的概率都接近。
+
+### 融合问题
+
+布莱克韦尔-杜宾斯定理研究给定*过去*时*未来*的条件分布。
+
+在时刻 $n$，观察到 $(x_1,\ldots,x_n)$ 之后，每个主体对所有未来事件形成一个条件分布：
+
+$$
+P(\,\cdot\,|\,\mathscr{F}_n)(\omega), \qquad
+Q(\,\cdot\,|\,\mathscr{F}_n)(\omega).
+$$
+
+这些是关于整个未来路径的概率测度，而不仅仅是下一个观察。
+
+融合问题询问是否
+
+$$
+d_n \;:=\; \bigl\|P(\,\cdot\,|\,\mathscr{F}_n) - Q(\,\cdot\,|\,\mathscr{F}_n)\bigr\|_{\mathrm{TV}}
+\;\longrightarrow\; 0
+$$
+
+当 $n \to \infty$ 时几乎必然成立。
+
+
+## 似然比鞅
+
+我们的主要工具是拉东-尼科迪姆导数过程。
+
+### 似然比
+
+由于对于每个 $n$，$Q \ll P$ 蕴含 $Q_n \ll P_n$，拉东-尼科迪姆
+定理保证了似然比的存在性
+
+$$
+Z_n = \frac{dQ_n}{dP_n}, \qquad Z_n \geq 0 \;\; P\text{-a.s.},
+\qquad \mathbb{E}_P[Z_n] = 1.
+$$
+
+关键的结构性质是，全局绝对连续性 $Q \ll P$
+蕴含在整个 $(\Omega, \mathscr{F})$ 上存在总体拉东-尼科迪姆导数 $Z = dQ/dP$，
+并且
+
+$$
+Z_n = \mathbb{E}_P[Z \,|\, \mathscr{F}_n] \qquad P\text{-a.s.}
+$$
+
+也就是说，$\{Z_n, \mathscr{F}_n\}_{n \geq 1}$ 是一个非负、一致
+可积的 $P$-鞅。
+
+```{prf:lemma} 鞅收敛
+:label: martingale_convergence
+
+似然比过程 $\{Z_n\}$ 满足：
+
+1. 当 $n \to \infty$ 时，$Z_n \to Z_\infty$ $P$-几乎必然。
+2. $Z_\infty = \mathbb{E}_P[Z \,|\, \mathscr{F}_\infty]$ $P$-a.s.
+3. $Z_n \to Z_\infty$ 在 $L^1(P)$ 中：$\;\mathbb{E}_P[|Z_n - Z_\infty|] \to 0$。
+
+*证明概要。*非负性和鞅性质给出了在 $L^1(P)$ 中的
+有界性。
+
+然后几乎必然收敛由杜布鞅
+收敛定理 {cite:t}`doob1953` 得出。
+
+一致可积性（它通过条件延森不等式
+由 $Z \in L^1(P)$ 得出）将其提升到
+$L^1(P)$ 收敛。$\square$
+```
+
+### 将条件测度与似然比联系起来
+
+下面的恒等式将似然比与条件分布联系起来。
+
+在集合 $\{Z_n > 0\}$ 上，$Q(\,\cdot\,|\,\mathscr{F}_n)$ 关于 $P(\,\cdot\,|\,\mathscr{F}_n)$ 的
+拉东-尼科迪姆导数为
+
+$$
+\frac{d\,Q(\,\cdot\,|\,\mathscr{F}_n)}{d\,P(\,\cdot\,|\,\mathscr{F}_n)}
+= \frac{Z_\infty}{Z_n}
+\qquad P\text{-a.s. on } \{Z_n > 0\}.
+$$
+
+于是应用带 $f = Z_\infty / Z_n$ 的全变差公式给出
+
+$$
+d_n
+= \mathbb{E}_{P(\cdot|\mathscr{F}_n)}\!\left[\left(\frac{Z_\infty}{Z_n} - 1\right)^{\!+}\right]
+= 1 - \mathbb{E}_{P(\cdot|\mathscr{F}_n)}\!\left[\min\!\left(\frac{Z_\infty}{Z_n},\,1\right)\right].
+$$
+
+两边乘以 $Z_n$ 并取 $P$-期望（然后对 $\mathscr{F}_n$-可测的 $g$ 使用 $\mathbb{E}_P[Z_n \, g(\mathscr{F}_n)] = \mathbb{E}_Q[g(\mathscr{F}_n)]$）：
+
+$$
+2\,\mathbb{E}_Q[d_n] \;=\; \mathbb{E}_P[|Z_\infty - Z_n|],
+$$
+
+因此鞅的 $L^1(P)$ 收敛控制了全变差距离趋于零的速度。
+
+
+## 布莱克韦尔-杜宾斯定理
+
+```{prf:theorem} 布莱克韦尔-杜宾斯（1962）
+:label: blackwell_dubins
+
+设 $P$ 和 $Q$ 是 $(\Omega, \mathscr{F})$ 上的概率测度，满足
+$Q \ll P$。
+
+定义
+
+$$
+d_n = \bigl\|P(\,\cdot\,|\,\mathscr{F}_n) - Q(\,\cdot\,|\,\mathscr{F}_n)\bigr\|_{\mathrm{TV}}.
+$$
+
+那么 $d_n \to 0$ $Q$-几乎必然。
+```
+
+证明有三个步骤。
+
+步骤 1. 通过 $Z_n$ 表示 $d_n$。
+
+如上所示，$d_n$ 可以用 $Z_\infty / Z_n$ 表示，其中 $Z_n = \mathbb{E}_P[Z \,|\, \mathscr{F}_n]$ 且 $Z = dQ/dP$。
+
+这将问题化归为关于 $P$ 下一个鞅的陈述。
+
+步骤 2. $\{d_n\}$ 是一个非负上鞅。
+
+对更多信息取条件平均地降低了可区分性。
+
+形式上，因为
+$P(\,\cdot\,|\,\mathscr{F}_n) = \mathbb{E}[P(\,\cdot\,|\,\mathscr{F}_{n+1})\,|\,\mathscr{F}_n]$
+且全变差是凸的，
+
+$$
+\mathbb{E}_Q[d_{n+1}\,|\,\mathscr{F}_n] \leq d_n \qquad Q\text{-a.s.}
+$$
+
+因此 $\{d_n, \mathscr{F}_n\}$ 是 $[0,1]$ 中的非负 $Q$-上鞅。
+
+由杜布定理，$d_n \to d_\infty$ $Q$-几乎必然，其中 $d_\infty$ 是某个取值于 $[0,1]$ 的随机变量。
+
+步骤 3. 几乎必然的极限为零。
+
+由步骤 1 和 $L^1$ 界：
+
+$$
+\mathbb{E}_Q[d_n] = \tfrac{1}{2}\,\mathbb{E}_P[|Z_\infty - Z_n|] \to 0.
+$$
+
+右边由鞅的 $L^1(P)$ 收敛而消失。
+
+因此 $d_n \to 0$ 在 $L^1(Q)$ 中，从而在 $Q$-概率意义下成立。
+
+由于 $d_n$ 已经 $Q$-几乎必然收敛，其极限必须满足 $d_\infty = 0$ $Q$-a.s. $\square$
+
+```{prf:remark} 单边绝对连续性 vs. 相互绝对连续性
+:label: one_sided_vs_mutual
+
+该定理只要求 $Q \ll P$，而不要求 $P \ll Q$。
+
+单边绝对连续性 $Q \ll P$ 给出 $Q$-几乎必然的融合。
+
+由于 $Q \ll P$ 意味着每个 $P$-零集也是 $Q$-零集，$Q$-a.s. 收敛并不*自动*蕴含 $P$-a.s. 收敛。
+
+要得出在*两个*主体的测度下 $d_n \to 0$，需要相互绝对连续性 $P \sim Q$。
+
+在加上 $P \ll Q$ 之后，可以将 $P$ 和 $Q$ 的角色互换运行该证明，从而也得到 $d_n \to 0$ $P$-a.s.。
+```
+
+```{prf:remark} 尖锐性
+:label: sharpness
+
+绝对连续性很重要。
+
+当 $P$ 和 $Q$ 奇异时，融合可能完全失败。
+
+下面的点质量例子对每个 $n$ 都有 $d_n = 1$。
+
+对于乘积测度，后面的角谷定理给出了一个尖锐的等价性与奇异性二分法。
+```
+
+
+## 贝塔-伯努利模型
+
+在转向 Python 之前，我们介绍贯穿所有
+模拟的主要例子。
+
+### 模型
+
+假设数据流 $(x_1, x_2, \ldots)$ 由独立同分布的伯努利
+抽样构成，未知概率为 $p^* \in (0,1)$。
+
+主体 $i$ 有一个贝塔先验：
+
+$$
+p \sim \mathrm{Beta}(\alpha_i, \beta_i), \qquad i = 1, 2.
+$$
+
+在观察到 $n$ 次抽样中有 $k$ 次成功之后，贝叶斯法则给出
+后验
+
+$$
+p \,|\, x^n \;\sim\; \mathrm{Beta}(\alpha_i + k,\; \beta_i + n - k),
+$$
+
+而单步向前预测概率为
+
+$$
+\hat{p}_i^n = \mathbb{E}[p\,|\,x^n] = \frac{\alpha_i + k}{\alpha_i + \beta_i + n}.
+$$
+
+由强大数定律，$k/n \to p^*$ 几乎必然，因此无论
+主体的初始先验 $(\alpha_i, \beta_i)$ 如何，$\hat{p}_1^n$ 和 $\hat{p}_2^n$ 都收敛到 $p^*$。
+
+### 边缘似然与似然比
+
+对于每个固定的值 $p \in (0,1)$，令 $P_p$ 表示无限序列上的独立同分布伯努利$(p)$
+概率律。
+
+主体 $i$ 不知道 $p$。
+
+相反，主体 $i$ 对 $p$ 放置先验密度 $\pi_i$，这通过下式在数据序列上诱导出
+一个概率测度 $P_i$
+
+$$
+P_i(A) = \int_0^1 P_p(A)\,\pi_i(p)\,dp
+\qquad \text{对于每个事件 } A.
+$$
+
+因此 $P_i$ 是主体在对 $p$ 的不确定性取平均之后关于
+历史的边缘概率测度。
+
+特别地，如果 $x^n$ 是一个精确的观察历史，有 $k$ 次成功，那么
+$P_i(x^n)$ 表示主体 $i$ 在这个混合测度下赋予该历史的概率。
+
+要计算它，从贝塔密度出发
+
+$$
+\pi_i(p)
+= \frac{p^{\alpha_i - 1} (1-p)^{\beta_i - 1}}{B(\alpha_i, \beta_i)},
+\qquad 0 < p < 1.
+$$
+
+给定 $p$，该有序历史的概率为 $p^k (1-p)^{n-k}$。
+
+因此
+
+$$
+\begin{aligned}
+P_i(x^n)
+&= \int_0^1 p^k (1-p)^{n-k} \pi_i(p)\, dp \\
+&= \frac{1}{B(\alpha_i, \beta_i)}
+\int_0^1 p^{\alpha_i + k - 1} (1-p)^{\beta_i + n - k - 1}\, dp \\
+&= \frac{B(\alpha_i + k,\; \beta_i + n - k)}{B(\alpha_i,\, \beta_i)}.
+\end{aligned}
+$$
+
+其中 $B(a,b) = \Gamma(a)\Gamma(b)/\Gamma(a+b)$ 是贝塔函数。
+
+这个表达式是有序历史 $x^n$ 的概率。
+
+它仅通过计数 $k$ 依赖于数据，因此成功次数相同的历史获得相同的概率。
+
+因此时刻 $n$ 处的似然比为
+
+$$
+Z_n = \frac{P_{1,n}(x^n)}{P_{2,n}(x^n)}
+= \frac{B(\alpha_2,\, \beta_2)}{B(\alpha_1,\, \beta_1)}
+\cdot
+\frac{B(\alpha_1 + k,\, \beta_1 + n - k)}{B(\alpha_2 + k,\, \beta_2 + n - k)}.
+$$
+
+这是 $P_2$（主体 2 的概率）下的一个鞅，它几乎必然
+收敛到一个有限正极限 $Z_\infty$，反映了对于任何具有正参数的贝塔先验，
+$P_1 \sim P_2$ 这一事实。
+
+### 精确的布莱克韦尔-杜宾斯距离
+
+对于贝塔-伯努利模型，存在一个 $d_n$ 的简洁公式。
+
+由德菲内蒂定理，给定过去时每个主体对*未来无限序列*的条件分布
+是独立同分布伯努利$(p)$
+过程的混合，其中 $p$ 从后验贝塔分布抽取。
+
+由于不同 $p$ 的伯努利$(p)^{\infty}$ 测度相互
+奇异（经验频率精确地识别出 $p$），关于未来的两个条件分布之间的全变差距离
+等于关于参数 $p$ 的两个后验分布之间的全变差
+距离。
+
+全变差距离为
+
+$$
+d_n
+= \bigl\|\mathrm{Beta}(\alpha_1 + k_n,\,\beta_1 + n - k_n)
+- \mathrm{Beta}(\alpha_2 + k_n,\,\beta_2 + n - k_n)\bigr\|_{\mathrm{TV}}.
+$$
+
+当 $k_n/n \to p^*$ 且 $n \to \infty$ 时，两个后验贝塔都集中于 $p^*$ 附近，方差为 $1/n$ 阶，因此 $d_n \to 0$。
+
+下面的代码实现了上述贝塔-伯努利更新、预测概率、全变差距离和似然比的计算。
+
+```{code-cell} ipython3
+def beta_bernoulli_update(data, a0, b0):
+    """
+    序贯贝塔-伯努利贝叶斯更新。
+    """
+    n = len(data)
+    cum_k = np.concatenate([[0], np.cumsum(data)])   # 累积成功次数
+    ns    = np.arange(n + 1)                          # 0, 1, ..., n
+    a_post = a0 + cum_k
+    b_post = b0 + (ns - cum_k)
+    return a_post, b_post
+
+
+def predictive_prob(a_post, b_post):
+    """单步向前预测概率 P(X=1 | data)。"""
+    return a_post / (a_post + b_post)
+
+
+def tv_distance_beta(a1, b1, a2, b2, n_grid=2000):
+    """
+    通过网格求积计算 Beta(a1,b1) 和 Beta(a2,b2) 之间的全变差距离。
+    在 (0,1) 上使用精细网格。
+    """
+    x  = np.linspace(1e-8, 1 - 1e-8, n_grid)
+    dx = x[1] - x[0]
+    p1 = beta_dist.pdf(x, a1, b1)
+    p2 = beta_dist.pdf(x, a2, b2)
+    return 0.5 * np.sum(np.abs(p1 - p2)) * dx
+
+
+def log_likelihood_ratio(data, a1, b1, a2, b2):
+    """
+    计算对数似然比 log Z_n = log P1_n(data) - log P2_n(data)
+    对 `data` 的每个前缀。
+
+    返回一个长度为 len(data) + 1 的数组，从 0 开始（数据之前）。
+    """
+    a1p, b1p = beta_bernoulli_update(data, a1, b1)
+    a2p, b2p = beta_bernoulli_update(data, a2, b2)
+    log_P1 = betaln(a1p, b1p) - betaln(a1, b1)
+    log_P2 = betaln(a2p, b2p) - betaln(a2, b2)
+    return log_P1 - log_P2
+
+
+def run_simulation(p_true, a1, b1, a2, b2, n_steps, seed=0):
+    """
+    模拟融合实验的一次实现。
+
+    返回一个字典，包含长度为 n_steps + 1 的数组（索引 0 = 先验）。
+    """
+    rng  = np.random.default_rng(seed)
+    data = rng.binomial(1, p_true, n_steps)
+
+    a1p, b1p = beta_bernoulli_update(data, a1, b1)
+    a2p, b2p = beta_bernoulli_update(data, a2, b2)
+
+    pred1    = predictive_prob(a1p, b1p)
+    pred2    = predictive_prob(a2p, b2p)
+    tv_1step = np.abs(pred1 - pred2)
+
+    # 后验贝塔之间的全变差；在此模型中它等于 d_n
+    tv_beta = np.array([
+        tv_distance_beta(a1p[i], b1p[i], a2p[i], b2p[i])
+        for i in range(n_steps + 1)
+    ])
+
+    log_Z = log_likelihood_ratio(data, a1, b1, a2, b2)
+
+    return dict(data=data, pred1=pred1, pred2=pred2,
+                tv_1step=tv_1step, tv_beta=tv_beta, log_Z=log_Z)
+```
+
+### 模拟
+
+我们选择两个对一枚硬币偏差持有非常不同信念的主体，这枚硬币正面朝上的真实概率为 $p^* = 0.65$。
+
+- 主体 1（怀疑者）：先验 $\mathrm{Beta}(1, 8)$，因此
+  $\hat{p}_1^0 = 1/9 \approx 0.11$。
+- 主体 2（乐观者）：先验 $\mathrm{Beta}(8, 1)$，因此
+  $\hat{p}_2^0 = 8/9 \approx 0.89$。
+
+两个先验都支撑在整个 $(0,1)$ 上，因此 $P_1 \sim P_2$。
+
+布莱克韦尔-杜宾斯保证融合。
+
+下图展示了这种融合的样子。
+
+```{code-cell} ipython3
+---
+mystnb:
+  figure:
+    caption: |
+      贝塔-伯努利例子中的融合。
+      四个面板显示后验预测均值、全变差距离 $d_n$、对数似然比 $\log Z_n$，以及选定视界处的后验密度。
+    name: fig-merging-of-opinions-beta-bernoulli
+---
+p_true = 0.65
+a1, b1 = 1.0, 8.0    # 怀疑者
+a2, b2 = 8.0, 1.0    # 乐观者
+n_steps = 600
+
+sim = run_simulation(p_true, a1, b1, a2, b2, n_steps, seed=7)
+steps = np.arange(n_steps + 1)
+
+fig, axes = plt.subplots(2, 2, figsize=(11, 7))
+ax = axes[0, 0]
+ax.plot(steps, sim['pred1'], color='steelblue', lw=2,
+        label=r'主体 1 $\hat p_1^n$（先验：怀疑者）')
+ax.plot(steps, sim['pred2'], color='firebrick', lw=2,
+        label=r'主体 2 $\hat p_2^n$（先验：乐观者）')
+ax.axhline(p_true, color='black', lw=1.0, ls='--',
+           label=f'真值 $p^*={p_true}$')
+ax.set_xlabel('观察数 $n$')
+ax.set_ylabel('预测概率')
+ax.set_title('(a) 后验预测均值')
+ax.legend(fontsize=8)
+ax.set_ylim(0, 1)
+
+ax = axes[0, 1]
+ax.semilogy(steps, sim['tv_beta'] + 1e-10, color='mediumpurple', lw=2)
+ax.set_xlabel('观察数 $n$')
+ax.set_ylabel(
+    r'$d_n = \|P(\cdot|\mathscr{F}_n)'
+    r' - Q(\cdot|\mathscr{F}_n)\|_{\mathrm{TV}}$'
+)
+ax.set_title(r'(b) 全变差距离 $d_n$')
+ax.set_ylim(bottom=1e-4)
+
+ax = axes[1, 0]
+ax.plot(steps, sim['log_Z'], color='darkorange', lw=2)
+ax.axhline(0, color='black', lw=0.8, ls=':')
+ax.set_xlabel('观察数 $n$')
+ax.set_ylabel(r'$\log Z_n$')
+ax.set_title(r'(c) 对数似然比')
+
+ax = axes[1, 1]
+xs = np.linspace(0.01, 0.99, 500)
+epochs = [0, 20, 100, n_steps]
+colors = plt.cm.viridis(np.linspace(0.2, 0.85, len(epochs)))
+
+for epoch, col in zip(epochs, colors):
+    k_e = int(np.sum(sim['data'][:epoch]))
+    pdf1 = beta_dist.pdf(xs, a1 + k_e, b1 + epoch - k_e)
+    pdf2 = beta_dist.pdf(xs, a2 + k_e, b2 + epoch - k_e)
+    ax.plot(xs, pdf1, color=col, lw=2, ls='-')
+    ax.plot(xs, pdf2, color=col, lw=2, ls='--')
+
+ax.axvline(p_true, color='black', lw=1.0, ls=':', label=f'$p^*={p_true}$')
+ax.set_xlabel('$p$')
+ax.set_ylabel('后验密度')
+ax.set_title('(d) 后验密度')
+
+from matplotlib.lines import Line2D
+handles = [
+    Line2D([0], [0], color='black', lw=2, label='主体 1'),
+    Line2D([0], [0], color='black', lw=2, ls='--', label='主体 2'),
+]
+for epoch, col in zip(epochs, colors):
+    handles.append(Line2D([0], [0], color=col, lw=2, label=f'$n={epoch}$'))
+handles.append(
+    Line2D([0], [0], color='black', lw=1.0, ls=':', label=f'$p^*={p_true}$')
+)
+ax.legend(handles=handles, fontsize=8)
+ax.set_ylim(bottom=0)
+
+plt.tight_layout()
+plt.show()
+```
+
+四个面板显示：
+
+- 面板 (a)：从 $\hat{p}_1^0 \approx 0.11$ 和
+  $\hat{p}_2^0 \approx 0.89$ 出发，两个主体的预测概率都
+  收敛到 $p^* = 0.65$。
+- 面板 (b)：全变差距离 $d_n$ 在
+  对数刻度上衰减到零，与定理一致。
+- 面板 (c)：对数似然比 $\log Z_n$ 收敛到一个有限
+  值，这与本例中的相互绝对连续性一致。
+- 面板 (d)：两个主体的后验贝塔密度起初相距
+  甚远（一个接近 0，一个接近 1），并逐渐集中到以真值为中心的相同
+  分布。
+
+
+### 跨多条路径的几乎必然收敛
+
+为了说明该定理的几乎必然特性，我们运行许多独立重复。
+
+该定理关注参考测度下的几乎每条路径，而不仅仅是跨路径的平均。
+
+```{code-cell} ipython3
+---
+mystnb:
+  figure:
+    caption: |
+      跨多条样本路径的几乎必然融合。
+      左面板绘制全变差距离，右面板绘制对数似然比 $\log Z_n$。
+    name: fig-merging-of-opinions-many-paths
+---
+N_paths = 80
+n_steps = 500
+
+fig, axes = plt.subplots(1, 2, figsize=(11, 4))
+
+ax_tv  = axes[0]
+ax_log = axes[1]
+
+tv_all   = np.empty((N_paths, n_steps + 1))
+logZ_all = np.empty((N_paths, n_steps + 1))
+steps    = np.arange(n_steps + 1)
+
+for i in range(N_paths):
+    s = run_simulation(p_true, a1, b1, a2, b2, n_steps, seed=i)
+    tv_all[i]   = s['tv_beta']
+    logZ_all[i] = s['log_Z']
+
+for i in range(N_paths):
+    ax_tv.semilogy(steps, tv_all[i] + 1e-10, color='steelblue',
+                   lw=0.8, alpha=0.3)
+ax_tv.semilogy(steps, tv_all.mean(axis=0) + 1e-10,
+               color='black', lw=2, label='跨路径均值')
+ax_tv.set_xlabel('观察数 $n$')
+ax_tv.set_ylabel(r'$d_n$（对数刻度）')
+ax_tv.legend()
+
+for i in range(N_paths):
+    ax_log.plot(steps, logZ_all[i], color='firebrick',
+                lw=0.8, alpha=0.3)
+ax_log.plot(steps, logZ_all.mean(axis=0),
+            color='black', lw=2, label='跨路径均值')
+ax_log.axhline(0, color='gray', lw=0.8, ls=':')
+ax_log.set_xlabel('观察数 $n$')
+ax_log.set_ylabel(r'$\log Z_n$')
+ax_log.legend()
+
+plt.tight_layout()
+plt.show()
+
+# 有限视界摘要
+frac_below = np.mean(tv_all[:, -1] < 0.30)
+mean_final = tv_all[:, -1].mean()
+print(f"n = {n_steps} 时 d_n < 0.30 的路径比例: {frac_below:.2f}")
+print(f"n = {n_steps} 时的平均距离: {mean_final:.3f}")
+```
+
+在这个有限视界处，距离已从初始水平大幅下降，但尚未接近零。
+
+这仍然与定理一致，因为几乎必然收敛是一个渐近陈述。
+
+
+### $d_n$ 的上鞅性质
+
+证明依赖于 $\{d_n\}$ 是一个非负上鞅。
+
+我们可以通过观察跨多条路径的平均增量来数值地说明这一点。
+
+```{code-cell} ipython3
+---
+mystnb:
+  figure:
+    caption: |
+      上鞅性质的一个说明。
+      图中显示 $d_n$ 的平均增量及其跨多条模拟路径的累积和。
+    name: fig-merging-of-opinions-supermartingale
+---
+diffs = np.diff(tv_all, axis=1)          # 形状 (N_paths, n_steps)
+mean_diffs = diffs.mean(axis=0)          # 每步的平均增量
+cum_sum   = np.cumsum(mean_diffs)        # 累积平均变化
+
+fig, axes = plt.subplots(1, 2, figsize=(10, 4))
+
+ax = axes[0]
+ax.plot(mean_diffs[:200], color='purple', lw=2)
+ax.axhline(0, color='black', lw=0.8, ls='--')
+ax.fill_between(range(200), mean_diffs[:200], 0,
+                where=(mean_diffs[:200] < 0), alpha=0.25,
+                color='purple', label='负增量')
+ax.fill_between(range(200), mean_diffs[:200], 0,
+                where=(mean_diffs[:200] > 0), alpha=0.25,
+                color='red', label='正增量')
+ax.set_xlabel('观察数 $n$')
+ax.set_ylabel(r'$\mathbb{E}[d_{n+1} - d_n]$')
+ax.legend(fontsize=8)
+
+ax = axes[1]
+ax.plot(cum_sum[:200], color='darkorange', lw=2)
+ax.axhline(0, color='black', lw=0.8, ls='--')
+ax.set_xlabel('观察数 $n$')
+ax.set_ylabel(r'$d_n$ 的累积平均变化')
+
+plt.tight_layout()
+plt.show()
+
+frac_decrease = np.mean(mean_diffs < 0)
+print(f"平均减量的步骤比例: {frac_decrease:.2%}")
+```
+
+平均增量在大多数步骤为负，累积漂移向下。
+
+这只是一个说明，而不是证明，因为它使用的是无条件平均，而不是定理中完整的条件期望。
+
+
+## 融合的失败：相互奇异
+
+当假设 $Q \ll P$ 失败时会发生什么？
+
+奇异情形是最简洁的反例。
+
+### 点质量先验
+
+假设两个主体都持有退化（点质量）先验：
+
+- 主体 P：确信 $p = p_P = 0.30$。
+- 主体 Q：确信 $p = p_Q = 0.75$。
+
+由于 $P$ 仅对经验频率收敛到 $0.30$ 的序列赋值，而 $Q$ 仅对经验频率收敛到 $0.75$ 的序列赋值，这两个测度相互奇异：$P \perp Q$。
+
+条件分布不更新，因为两个主体都已经确信各自的模型。
+
+对于定理的对象，即整个未来路径的条件律，
+
+$$
+\|P(\,\cdot\,|\,\mathscr{F}_n) - Q(\,\cdot\,|\,\mathscr{F}_n)\|_{\mathrm{TV}}
+= \|P - Q\|_{\mathrm{TV}} = 1
+\quad \text{对所有 } n.
+$$
+
+这个等式成立是因为具有不同成功概率的无限乘积伯努利测度是奇异的。
+
+如果我们只向前看一步，预测距离为 $|p_P - p_Q| = 0.45$。
+
+这小于一，但它不是出现在布莱克韦尔-杜宾斯中的量。
+
+```{code-cell} ipython3
+---
+mystnb:
+  figure:
+    caption: |
+      奇异先验下融合的失败。
+      整个未来路径距离保持在一，
+      而单步预测差距保持
+      在 $|p_P - p_Q|$。
+    name: fig-merging-of-opinions-singular-priors
+---
+p_P = 0.30
+p_Q = 0.75
+n_steps = 500
+
+tv_singular_full = np.ones(n_steps + 1)
+tv_singular_1step = np.full(n_steps + 1, np.abs(p_P - p_Q))
+
+sim_abs_cont = run_simulation(
+    p_Q, 1.0, 8.0, 8.0, 1.0, n_steps, seed=1
+)
+
+fig, ax = plt.subplots(figsize=(8, 4))
+ax.plot(np.arange(n_steps + 1), tv_singular_full,
+        color='firebrick', lw=2,
+        label=r'奇异：整路径 $d_n = 1$')
+ax.plot(np.arange(n_steps + 1), tv_singular_1step,
+        color='gray', lw=2, ls=':',
+        label=r'单步差距 $= |p_P - p_Q|$')
+ax.plot(np.arange(n_steps + 1),
+        sim_abs_cont['tv_beta'],
+        color='steelblue', lw=2,
+        label=(r'$\mathrm{Beta}(1,8)$ vs'
+               r' $\mathrm{Beta}(8,1)$'))
+ax.set_xlabel('观察数 $n$')
+ax.set_ylabel(r'$d_n$')
+ax.legend(fontsize=8)
+ax.set_ylim(0, 1.05)
+
+plt.tight_layout()
+plt.show()
+```
+
+对比是鲜明的。
+
+对于相互绝对连续的先验，$d_n$ 衰减到零。
+
+对于奇异的点质量先验，整个未来路径距离永远保持在一。
+
+更多的数据无法调和这两个主体，因为每个主体都排除了对方赋予正概率的路径。
+
+
+## 角谷定理：融合何时成立？
+
+一个自然的问题是：对于哪些乘积测度，布莱克韦尔-杜宾斯
+假设 $Q \ll P$ 成立？
+
+对于无限乘积测度，答案由
+{cite:t}`kakutani1948` 的经典结果给出。
+
+### 海林格亲和度
+
+```{prf:definition} 海林格亲和度
+:label: hellinger_affinity
+
+对于 $(S, \mathscr{S})$ 上具有共同
+支配测度 $\lambda$ 的概率测度 $P_n$ 和 $Q_n$，**海林格亲和度**为
+
+$$
+\rho_n = \int_S \sqrt{\frac{dP_n}{d\lambda} \cdot \frac{dQ_n}{d\lambda}}\,d\lambda
+\;\in\; [0, 1].
+$$
+
+$\rho_n = 1$ 当且仅当 $P_n = Q_n$；$\rho_n = 0$ 当且仅当 $P_n \perp Q_n$。
+```
+
+对于两个特定的一维族：
+
+- 高斯：$P_n = \mathcal{N}(\mu_n, 1)$ vs $Q_n = \mathcal{N}(0,1)$：
+
+$$
+\rho_n^{\text{Gauss}} = \exp\!\left(-\frac{\mu_n^2}{8}\right).
+$$
+
+- 伯努利：$P_n = \mathrm{Bernoulli}(p)$ vs $Q_n = \mathrm{Bernoulli}(q)$：
+
+$$
+\rho_n^{\text{Bern}} = \sqrt{pq} + \sqrt{(1-p)(1-q)}.
+$$
+
+### 角谷二分法
+
+```{prf:theorem} 角谷（1948）
+:label: kakutani_dichotomy
+
+设 $P = \bigotimes_{n=1}^\infty P_n$ 和 $Q = \bigotimes_{n=1}^\infty Q_n$
+是无限乘积测度，其因子逐对等价：对于每个 $n$，$P_n \sim Q_n$。
+
+那么要么 $P \sim Q$，要么 $P \perp Q$；不存在
+中间情形。
+
+具体地，
+
+$$
+P \sim Q
+\quad \iff \quad
+\prod_{n=1}^\infty \rho_n > 0
+\quad \iff \quad
+\sum_{n=1}^\infty (1 - \rho_n) < \infty.
+$$
+
+如果 $\prod_{n=1}^\infty \rho_n = 0$，那么 $P \perp Q$。
+
+*证明思路。*
+一个标准证明研究似然比鞅
+$Z_N = \prod_{n=1}^N (dP_n/dQ_n)$ 连同恒等式
+$\mathbb{E}_Q[\sqrt{Z_N}] = \prod_{n=1}^N \rho_n$。
+
+乘积保持正对应于等价性，而乘积坍缩到零对应于奇异性。
+
+$\square$
+```
+
+### 对融合的蕴含
+
+对于独立同分布类型的序列，角谷定理给出以下图景：
+
+| 情形 | $\sum_n (1-\rho_n)$ | 结论 | 融合？ |
+|---|---|---|---|
+| 对所有 $n$，$P_n = Q_n$ | $0$ | $P = Q$ | 平凡地是 |
+| $P_n \ne Q_n$ 且 $\sum_n (1-\rho_n) < \infty$ | 有限 | $P \sim Q$ | 是；布莱克韦尔-杜宾斯适用 |
+| $P_n = P \ne Q = Q_n$ 固定，$n \ge 1$ | $\infty$ | $P \perp Q$ | 否 |
+
+具有不同固定边缘分布的独立同分布情形是标准的不融合例子。
+
+如果两个主体对每个观察永久地赋予不同的分布，他们最终处于互不相交的概率世界中。
+
+### 一个高斯乘积测度例子
+
+我们用高斯乘积测度来说明角谷二分法。
+
+取 $Q = \mathcal{N}(0,1)^{\otimes\mathbb{N}}$ 作为参考测度，取 $P = \bigotimes_n \mathcal{N}(\mu_n,1)$ 作为备择。
+
+$\mu_n$ 的三种选择：
+
+1. $\mu_n = \mu > 0$ 常数（$\sum (1-\rho_n) = \infty$）$\Rightarrow P \perp Q$。
+2. $\mu_n = c/\!\sqrt{n}$（$\sum (1-\rho_n) \approx \sum c^2/(8n) = \infty$）$\Rightarrow P \perp Q$。
+3. $\mu_n = c/n$（$\sum (1-\rho_n) \approx \sum c^2/(8n^2) < \infty$）$\Rightarrow P \sim Q$。
+
+```{code-cell} ipython3
+N_max  = 2000
+ns     = np.arange(1, N_max + 1)
+c      = 2.0
+N_plot = 400
+rng    = np.random.default_rng(0)
+
+cases = [
+    (r'$\mu_n = c$（常数）', np.full(N_max, c)),
+    (r'$\mu_n = c/\sqrt{n}$', c / np.sqrt(ns)),
+    (r'$\mu_n = c/n$', c / ns),
+]
+```
+
+在常数漂移下，$\log Z_N$ 在 $Q$ 下漂移到 $-\infty$，因此 $Z_N \to 0$ $Q$-a.s. 且 $P \perp Q$。
+
+```{code-cell} ipython3
+---
+mystnb:
+  figure:
+    caption: |
+      常数漂移 $\mu_n = c$：
+      似然比坍缩（$P \perp Q$）。
+    name: fig-kakutani-constant
+---
+label, μ_seq = cases[0]
+x = rng.standard_normal(N_plot)
+log_Z_inc = μ_seq[:N_plot] * x - μ_seq[:N_plot]**2 / 2
+log_Z = np.concatenate([[0], np.cumsum(log_Z_inc)])
+
+fig, ax = plt.subplots(figsize=(8, 3))
+ax.plot(np.arange(N_plot + 1), log_Z,
+        color='darkorange', lw=2, label=label)
+ax.axhline(0, color='black', lw=0.8, ls=':')
+ax.set_xlabel('视界 $N$')
+ax.set_ylabel(r'$Q$ 下的 $\log Z_N$')
+ax.legend(fontsize=8)
+plt.tight_layout()
+plt.show()
+```
+
+$\mu_n = c/\sqrt{n}$ 的情形显示出相同的定性图景：尽管漂移消失，但消失得太慢。
+
+```{code-cell} ipython3
+---
+mystnb:
+  figure:
+    caption: |
+      漂移 $\mu_n = c/\sqrt{n}$：仍然
+      奇异（$P \perp Q$）。
+    name: fig-kakutani-sqrt
+---
+label, μ_seq = cases[1]
+x = rng.standard_normal(N_plot)
+log_Z_inc = μ_seq[:N_plot] * x - μ_seq[:N_plot]**2 / 2
+log_Z = np.concatenate([[0], np.cumsum(log_Z_inc)])
+
+fig, ax = plt.subplots(figsize=(8, 3))
+ax.plot(np.arange(N_plot + 1), log_Z,
+        color='purple', lw=2, label=label)
+ax.axhline(0, color='black', lw=0.8, ls=':')
+ax.set_xlabel('视界 $N$')
+ax.set_ylabel(r'$Q$ 下的 $\log Z_N$')
+ax.legend(fontsize=8)
+plt.tight_layout()
+plt.show()
+```
+
+只有在 $\mu_n = c/n$ 时 $\sum (1-\rho_n) < \infty$ 才成立，因此似然比保持非退化且 $P \sim Q$。
+
+布莱克韦尔-杜宾斯仅在此情形下适用。
+
+```{code-cell} ipython3
+---
+mystnb:
+  figure:
+    caption: |
+      漂移 $\mu_n = c/n$：似然
+      比稳定（$P \sim Q$）。
+    name: fig-kakutani-inv-n
+---
+label, μ_seq = cases[2]
+x = rng.standard_normal(N_plot)
+log_Z_inc = μ_seq[:N_plot] * x - μ_seq[:N_plot]**2 / 2
+log_Z = np.concatenate([[0], np.cumsum(log_Z_inc)])
+
+fig, ax = plt.subplots(figsize=(8, 3))
+ax.plot(np.arange(N_plot + 1), log_Z,
+        color='steelblue', lw=2, label=label)
+ax.axhline(0, color='black', lw=0.8, ls=':')
+ax.set_xlabel('视界 $N$')
+ax.set_ylabel(r'$Q$ 下的 $\log Z_N$')
+ax.legend(fontsize=8)
+plt.tight_layout()
+plt.show()
+```
+
+
+## 推广到连续时间
+
+同样的逻辑推广到连续时间。
+
+### 吉尔萨诺夫定理与似然比过程
+
+在典范维纳空间上，$Q$ 为维纳测度（标准
+布朗运动 $W$），假设主体 $P$ 相信该过程有一个
+额外漂移 $\theta = \{\theta_s\}_{s \geq 0}$：
+
+$$
+W_t = \widetilde{W}_t + \int_0^t \theta_s\, ds,
+$$
+
+其中 $\widetilde{W}$ 是一个 $P$-布朗运动。
+
+吉尔萨诺夫-卡梅隆-马丁定理 {cite:p}`girsanov1960` 将
+似然比过程给出为随机指数
+
+$$
+Z_t
+= \exp\!\left(\int_0^t \theta_s\, dW_s - \frac{1}{2}\int_0^t \theta_s^2\, ds\right).
+$$
+
+$Z_t$ 始终是一个非负的 $Q$-局部鞅；它是一个真鞅
+当且仅当对所有 $t$，$\mathbb{E}_Q[Z_t] = 1$。
+
+诺维科夫条件 {cite:p}`novikov1972`，
+对所有 $T$，$\mathbb{E}_Q\!\left[\exp\!\left(\tfrac{1}{2}\int_0^T \theta_s^2\,ds\right)\right] < \infty$，
+是充分的。
+
+### 无穷远处的二分法
+
+$[0,+\infty)$ 上的一个关键微妙之处是局部绝对连续性*不*蕴含 $\mathscr{F}_\infty$ 上的全局绝对连续性。
+
+```{prf:remark} 无限视界的微妙之处
+:label: dichotomy_at_infinity
+
+假设 $Z_t$ 对每个有限视界都是一个真 $Q$-鞅，并令 $Z_t \to Z_\infty$ $Q$-a.s.
+
+如果 $\{Z_t\}$ 在 $[0,\infty)$ 上一致可积，那么在 $\mathscr{F}_\infty$ 上 $P \ll Q$，且 $dP/dQ = Z_\infty$。
+
+对于布莱克韦尔-杜宾斯结论，我们需要在 $\mathscr{F}_\infty$ 上 $Q \ll P$（反方向）。
+
+在许多标准设定中，包括满足下面能量条件的确定性漂移，这些测度实际上在 $\mathscr{F}_\infty$ 上是*等价的*（$P \sim Q$），因此两个方向都成立。
+
+如果一致可积性失败，那么 $\mathscr{F}_\infty$ 上的全局绝对连续性可能失败。
+
+在许多标准例子中，包括一个非零常数漂移，这些测度实际上在 $\mathscr{F}_\infty$ 上是奇异的。
+```
+
+确定性漂移例子中的一个方便的充分条件是**能量条件**
+
+$$
+\int_0^\infty \theta_s^2\,ds < \infty \quad Q\text{-a.s.}
+$$
+
+非形式地说，这表示在无限视界上区分两个测度的信息总量是有限的。
+
+在能量条件下，$\mathscr{F}_\infty$ 上 $P \sim Q$，因此布莱克韦尔-杜宾斯适用，融合在两个测度下都成立。
+
+当 $\theta$ 是非零常数时，该条件失败，这些测度在 $\mathscr{F}_\infty$ 上奇异，融合不会发生。
+
+一旦在 $\mathscr{F}_\infty$ 上建立了 $Q \ll P$，连续时间布莱克韦尔-杜宾斯结果的证明
+就与离散时间证明完全相同。
+
+$\{d_t, \mathscr{F}_t\}$ 是 $[0,1]$ 中的非负 $Q$-上鞅，因此 $d_t \to d_\infty$ $Q$-a.s.
+
+$L^1$ 界
+$\mathbb{E}_Q[d_t] = \tfrac{1}{2}\mathbb{E}_P[|Z_t - Z_\infty|] \to 0$
+迫使 $d_\infty = 0$。
+
+
+## 应用
+
+### 贝叶斯学习
+
+最直接的应用是贝叶斯推断。
+
+假设数据 $(x_1, x_2, \ldots)$ 从真实测度 $Q^*$ 抽取。
+
+一个主体在族 $\{Q_\theta : \theta \in \Theta\}$ 上持有先验 $\pi$，诱导出边缘 $P = \int Q_\theta\,\pi(d\theta)$。
+
+如果 $Q^* \ll P$（即主体的边缘模型支配真值），那么布莱克韦尔-杜宾斯给出
+
+$$
+\bigl\|P(\,\cdot\,|\,x_1,\ldots,x_n) - Q^*(\,\cdot\,|\,x_1,\ldots,x_n)\bigr\|_{\mathrm{TV}}
+\to 0 \quad Q^*\text{-a.s.}
+$$
+
+这是贝叶斯一致性的一种强形式：主体的预测在真实测度下与真值融合。
+
+对真实参数邻域赋予正质量的先验通常保证对每个有限视界 $n$ 的*局部*绝对连续性 $Q^*_n \ll P_n$，但不保证布莱克韦尔-杜宾斯所要求的 $\mathscr{F}_\infty$ 上的全局条件 $Q^* \ll P$。
+
+例如，在具有非原子先验 $\pi$ 的贝塔-伯努利模型中，混合 $P = \int \mathrm{Bernoulli}(p)^{\infty}\,\pi(dp)$ 对每个 $n$ 满足 $Q^*_n \ll P_n$，但全局上 $Q^* \not\ll P$，因为集合 $\{\lim k_n/n = p^*\}$ 的 $Q^*$-测度为一，但 $P$-测度为零（不同的伯努利乘积测度相互奇异）。
+
+在额外结构下，全局绝对连续性确实成立，例如当参数空间有限或模型足够正则以允许杜布一致性论证时。
+
+{cite:t}`DiaconisFreedman1986` 研究贝叶斯估计的一致性，并在其他结果中表明，局部与全局绝对连续性之间的相互作用在确保后验收敛中起着核心作用。
+
+当 $P \perp Q^*$ 时，存在在 $Q^*$ 下概率为一但在 $P$ 下概率为零的事件，因此主体的信念仍然从根本上被错误设定。
+
+### 理性预期与异质先验
+
+在宏观经济学中，理性预期模型通常施加共同先验。
+
+布莱克韦尔-杜宾斯为较弱的初始一致性提供了动态论证。
+
+如果两个主体从等价先验出发并观察相同的历史，他们的条件预测最终在每个事件上达成一致。
+
+{cite:t}`aumann1976` 的一致性定理强化了这一点：具有
+共同先验的主体不能对后验概率"同意不一致"。
+
+布莱克韦尔-杜宾斯补充了奥曼，表明等价先验足以实现最终一致。
+
+### 遍历马尔可夫链
+
+对于具有转移核 $\Pi$ 和两个初始
+分布 $\mu$ 和 $\nu$ 的马尔可夫链，$n$-步分布为 $\mu\Pi^n$
+和 $\nu\Pi^n$。
+
+如果 $\Pi$ 是遍历的，具有唯一平稳分布
+$\pi$，两者都收敛到 $\pi$，因此
+
+$$
+\|\mu\Pi^n - \nu\Pi^n\|_{\mathrm{TV}}
+\leq \|\mu\Pi^n - \pi\|_{\mathrm{TV}} + \|\nu\Pi^n - \pi\|_{\mathrm{TV}}
+\to 0.
+$$
+
+这是融合的一种特殊形式，它*不*要求绝对连续性，因为遍历性已经迫使两个分布趋于相同的极限。
+
+布莱克韦尔-杜宾斯是非遍历或非马尔可夫环境的正确类比，在这些环境中不必存在单一的不变分布。
+
+
+## 融合的速率
+
+布莱克韦尔-杜宾斯是定性的。
+
+它告诉我们 $d_n \to 0$，但没有告诉我们速度有多快。
+
+界
+
+$$
+\mathbb{E}_Q[d_n] = \tfrac{1}{2}\,\mathbb{E}_P[|Z_n - Z_\infty|]
+$$
+
+表明融合的速率由似然比鞅的 $L^1(P)$ 收敛速率控制。
+
+在正则参数例子中，人们常常看到 $n^{-1/2}$ 型的行为。
+
+下图在贝塔-伯努利模型中检验了这个启发式。
+
+```{code-cell} ipython3
+---
+mystnb:
+  figure:
+    caption: |
+      贝塔-伯努利模型中平均融合距离的对数-对数图。
+      拟合斜率接近 $-1/2$，这与本实验中的平方根衰减一致。
+    name: fig-merging-of-opinions-rate
+---
+N_paths_rate = 200
+n_steps_rate = 800
+
+tv_rate = np.empty((N_paths_rate, n_steps_rate + 1))
+for i in range(N_paths_rate):
+    s = run_simulation(p_true, a1, b1, a2, b2, n_steps_rate, seed=100 + i)
+    tv_rate[i] = s['tv_beta']
+
+ns_rate  = np.arange(1, n_steps_rate + 1)
+mean_tv  = tv_rate[:, 1:].mean(axis=0)    # 平均 d_n, n = 1, ..., n_steps_rate
+
+# 使用样本的后半部分拟合参考线 d_n ~ C / sqrt(n)
+fit_start = 200
+log_ns  = np.log(ns_rate[fit_start:])
+log_tv  = np.log(mean_tv[fit_start:] + 1e-12)
+coeffs  = np.polyfit(log_ns, log_tv, 1)
+slope   = coeffs[0]
+
+# 参考曲线 C/sqrt(n)
+C_ref   = np.exp(coeffs[1])
+ref_curve = C_ref / np.sqrt(ns_rate)
+
+fig, ax = plt.subplots(figsize=(8, 4))
+ax.loglog(ns_rate, mean_tv,  color='steelblue', lw=2,
+          label=r'$\mathbb{E}_Q[d_n]$（蒙特卡洛）')
+ax.loglog(ns_rate, ref_curve, color='firebrick', lw=2, ls='--',
+          label=(rf'参考 $C/\sqrt{{n}}$'
+                 rf'（拟合斜率 $\approx {slope:.2f}$）'))
+ax.set_xlabel('样本大小 $n$')
+ax.set_ylabel(r'$\mathbb{E}_Q[d_n]$')
+ax.legend()
+plt.tight_layout()
+plt.show()
+
+print(f"拟合的对数-对数斜率: {slope:.3f}  (预测: -0.50)")
+```
+
+拟合样本的后半部分给出接近 $-0.5$ 的斜率。
+
+这与本模拟中的 $n^{-1/2}$ 标度一致。
+
+
+## 总结与推广
+
+布莱克韦尔-杜宾斯定理背后的逻辑流程是：
+
+$$
+Q \ll P
+\;\Longrightarrow\;
+Z = \frac{dQ}{dP} \in L^1(P)
+\;\Longrightarrow\;
+Z_n = \mathbb{E}_P[Z \,|\, \mathscr{F}_n]
+\xrightarrow{L^1(P)}
+Z_\infty
+\;\Longrightarrow\;
+d_n \xrightarrow{Q\text{-a.s.}} 0.
+$$
+
+要点：
+
+1. 单边绝对连续性 $Q \ll P$ 给出 $Q$-几乎必然的融合。对于在*两个*测度下的融合，需要相互绝对连续性 $P \sim Q$。
+
+2. 似然比鞅 $Z_n = \mathbb{E}_P[Z|\mathscr{F}_n]$ 及其 $L^1(P)$ 收敛驱动了这个结果。
+
+3. 更多的数据只能（在期望上）降低区分两个假设的难度。
+
+4. 对于无限乘积测度，角谷定理给出一个尖锐的等价性与奇异性二分法：要么 $P \sim Q$（当 $\sum_n (1 - \rho_n) < \infty$ 时），要么 $P \perp Q$（当该和发散时），不存在中间情形。
+
+5. 当 $P \sim Q$ 时，布莱克韦尔-杜宾斯适用，融合在两个测度下都发生；当 $P \perp Q$ 时，分歧永远持续。
+
+### 经济学中的应用
+
+一些有影响力的应用和推广是：
+
+- {cite}`KalaiLehrer1993Nash`：当先验关于真值绝对连续时，重复博弈学习驱动策略趋向纳什行为。
+- {cite}`KalaiLehrer1993Subjective`：在相同条件下，主观均衡和客观均衡渐近地重合。
+- {cite}`KalaiLehrer1994Merging`：为完全全变差收敛过强的环境引入了弱和强融合概念。
+- {cite}`KalaiLehrerSmorodinsky1999`：将融合与校准预测联系起来。
+- {cite}`JacksonKalaiSmorodinsky1999`：将德菲内蒂式的表示与贝叶斯学习和后验收敛联系起来。
+- {cite}`JacksonKalai1999`：社会学习削弱了依赖于跨群体持续分歧的声誉效应。
+- {cite}`Sandroni1998Nash`：表明近似绝对连续性条件足以在重复博弈中实现纳什型收敛。
+- {cite}`MillerSanchirico1999`：给出了一个替代证明，并从相互有利的赌注角度对持续分歧作出了经济学解释。
+- {cite}`LehrerSmorodinsky1996Compatible`：研究超越布莱克韦尔-杜宾斯绝对连续性的更广泛的兼容性概念。
+- {cite}`LehrerSmorodinsky1996Learning`：综述重复策略环境中的融合与学习。
+- {cite}`Nyarko1994`：将绝对连续性下的贝叶斯学习与趋向相关均衡的收敛联系起来。
+- {cite}`PomattoAlNajjarSandroni2014`：将定理推广到有限可加概率，并将融合与检验可操纵性联系起来。
+- {cite}`AcemogluChernozhukovYildiz2016`：表明当主体对信号结构本身不确定时分歧如何持续。
+
+### 一个来自概率论的配套结果
+
+{cite}`DiaconisFreedman1986` 研究贝叶斯估计的一致性，证明了涉及后验收敛的等价性，并提供了突出先验作用的反例。
+
+他们的工作与布莱克韦尔-杜宾斯处于相同的思想传统中，在经济学学习文献中通常与融合定理一起被引用。

--- a/lectures/survival_recursive_preferences.md
+++ b/lectures/survival_recursive_preferences.md
@@ -1,0 +1,1279 @@
+---
+jupytext:
+  text_representation:
+    extension: .md
+    format_name: myst
+    format_version: 0.13
+    jupytext_version: 1.11.1
+kernelspec:
+  display_name: Python 3
+  language: python
+  name: python3
+translation:
+  title: 递归偏好下的生存与长期动态
+  headings:
+    Overview: 概述
+    Environment: 环境
+    Environment::Aggregate endowment: 总禀赋
+    Environment::Heterogeneous beliefs: 异质信念
+    Environment::Recursive preferences: 递归偏好
+    Planner's problem: 规划者问题
+    Planner's problem::Modified discount factors: 修正贴现因子
+    'Planner''s problem::State variable: Pareto share': 状态变量：帕累托份额
+    Planner's problem::HJB equation: HJB 方程
+    Planner's problem::HJB equation::From discrete to continuous time: 从离散时间到连续时间
+    Planner's problem::HJB equation::Exact reduced ODE: 精确的约化 ODE
+    Survival conditions: 生存条件
+    Wealth dynamics decomposition: 财富动态分解
+    Wealth dynamics decomposition::Portfolio returns: 组合收益
+    Wealth dynamics decomposition::Consumption-wealth ratios: 消费-财富比
+    Wealth dynamics decomposition::Two comparative statics: 两个比较静态分析
+    Survival regions: 生存区域
+    Three survival channels: 三个生存渠道
+    Varying the IES: 改变 IES
+    Asymptotic results: 渐近结果
+    The separable case: 可分情形
+    Asset pricing implications: 资产定价含义
+    Optimistic and pessimistic distortions: 乐观和悲观扭曲
+    Long-run consumption distribution: 长期消费分布
+    Summary: 总结
+---
+
+(survival_recursive_preferences)=
+```{raw} jupyter
+<div id="qe-notebook-header" align="right" style="text-align:right;">
+        <a href="https://quantecon.org/" title="quantecon.org">
+                <img style="width:250px;display:inline;" width="250px" src="https://assets.quantecon.org/img/qe-menubar-logo.svg" alt="QuantEcon">
+        </a>
+</div>
+```
+
+# 递归偏好下的生存与长期动态
+
+```{index} single: Survival; Recursive Preferences
+```
+
+```{contents} Contents
+:depth: 2
+```
+
+## 概述
+
+本讲座研究 {cite:t}`Borovicka2020` 中关于长期生存的理论。
+
+经典的**市场选择假说**认为，信念较不准确的主体最终会被市场淘汰。
+
+这一结果由 {cite:t}`Sandroni2000Markets` 和 {cite:t}`Blume_Easley2006` 针对具有可分 CRRA 偏好的经济体进行了严格证明。
+
+Borovicka 表明，在 Epstein-Zin 递归偏好下，这一结论可能不成立。
+
+在递归偏好下，具有扭曲信念的主体可以生存，甚至可以占据主导地位。
+
+关键机制在于递归偏好将风险厌恶与跨期替代弹性(IES)分离开来。
+
+这种分离产生了三个对生存至关重要的渠道：
+
+1. *风险溢价渠道*奖励更乐观的主体持有更多的风险资产。
+1. *投机波动率渠道*通过对数收益率波动率惩罚激进的头寸。
+1. *储蓄渠道*在 IES 不等于 1 时改变消费和储蓄决策。
+
+在可分偏好下，只有前两个渠道存在。
+
+在递归偏好下，储蓄渠道可以推翻市场选择。
+
+```{note}
+本文建立在 {cite:t}`Duffie_Epstein1992a` 的连续时间递归效用表述之上，
+并采用 {cite:t}`Dumas_Uppal_Wang2000` 的规划者问题方法。
+
+市场选择假说的重要基础由
+{cite:t}`DeLong_etal1991` 和 {cite:t}`Blume_Easley1992` 奠定。
+```
+
+我们从一些导入开始。
+
+```{code-cell} ipython3
+import numpy as np
+import matplotlib.pyplot as plt
+import matplotlib as mpl  # i18n
+FONTPATH = "fonts/SourceHanSerifSC-SemiBold.otf"  # i18n
+mpl.font_manager.fontManager.addfont(FONTPATH)  # i18n
+mpl.rcParams['font.family'] = ['Source Han Serif SC']  # i18n
+```
+
+## 环境
+
+该经济体包含两个无限期存活的主体，用 $n \in \{1, 2\}$ 索引。
+
+这两个主体具有相同的递归偏好，但对总禀赋增长持有不同的信念。
+
+我们将 Borovička 的信念扭曲 $u^n$ 记作 $\omega^n$。
+
+### 总禀赋
+
+在真实概率测度 $P$ 下，总禀赋满足
+
+$$
+d \log Y_t = \mu_Y dt + \sigma_Y dW_t, \quad Y_0 > 0
+$$ (eq:srp_endowment)
+
+其中 $W$ 是标准布朗运动，$\mu_Y$ 是漂移，$\sigma_Y > 0$ 是波动率。
+
+### 异质信念
+
+主体 $n$ 认为漂移是 $\mu_Y + \omega^n \sigma_Y$ 而非 $\mu_Y$。
+
+参数 $\omega^n$ 在 $\omega^n > 0$ 时衡量乐观程度，在 $\omega^n < 0$ 时衡量悲观程度。
+
+主体 $n$ 的主观概率测度 $Q^n$ 由 Radon–Nikodym 导数定义
+
+$$
+M_t^n = \frac{dQ^n}{dP}\bigg|_t = \exp\left(-\frac{1}{2} |\omega^n|^2 t + \omega^n W_t\right)
+$$ (eq:radon_nikodym)
+
+在 $Q^n$ 下，过程 $W_t^n = W_t - \omega^n t$ 是一个布朗运动，主体 $n$ 感知到
+
+$$
+d \log Y_t = (\mu_Y + \omega^n \sigma_Y) dt + \sigma_Y dW_t^n .
+$$
+
+$\omega^n > 0$ 的主体对禀赋增长持乐观态度，而 $\omega^n < 0$ 的主体则持悲观态度。
+
+### 递归偏好
+
+两个主体都具有 Epstein-Zin 递归偏好。
+
+我们用 $\gamma > 0$ 表示相对风险厌恶，用 $\rho > 0$ 表示 IES 的倒数，用 $\beta > 0$ 表示时间偏好率。
+
+Duffie-Epstein-Zin 幸福函数为
+
+$$
+F(C, \nu)
+= \beta \frac{C^{1-\gamma}}{1-\gamma}
+\cdot
+\left(\frac{(1-\gamma) - (1-\rho)\nu / \beta}{\rho - \gamma}\right)^{(\gamma - \rho)/(1-\rho)}
+$$ (eq:felicity)
+
+其中 $\nu$ 是内生的贴现率。
+
+```{note}
+在离散时间中，Epstein-Zin 偏好通过 CES 聚合器将当前消费与未来效用的确定性等价物聚合在一起(参见 {doc}`advanced:doubts_or_variability`)。
+
+在连续时间中不存在"下一期 $V_{t+1}$"，因此 {cite:t}`Duffie_Epstein1992a` 将该递归重新表述为一个依赖于主体自身延续值率 $\nu$ 的幸福函数 $F(C,\nu)$。
+
+这两种表述编码了相同的风险厌恶 $\gamma$ 与 IES 倒数 $\rho$ 的分离。
+
+当 $\gamma = \rho$ 时，偏好退化为标准的可分 CRRA 情形。
+```
+
+## 规划者问题
+
+遵循 {cite:t}`Dumas_Uppal_Wang2000`，我们通过社会规划者问题来研究均衡配置。
+
+规划者为两个主体选择消费份额 $z^1$ 和 $z^2 = 1 - z^1$ 以及贴现率过程 $\nu^n$。
+
+### 修正贴现因子
+
+将信念扭曲吸收进修正贴现因子 $\tilde{\lambda}^n = \lambda^n M^n$ 是很方便的，其中 $M^n$ 是 Radon-Nikodym 导数 {eq}`eq:radon_nikodym`。
+
+这些过程满足
+
+$$
+d \log \tilde{\lambda}_t^n
+= -\left(\nu_t^n + \frac{1}{2} (\omega^n)^2\right) dt + \omega^n dW_t .
+$$ (eq:modified_discount)
+
+```{exercise}
+:label: ex_modified_discount
+
+推导 {eq}`eq:modified_discount`。
+
+*提示：* 使用 $\log \tilde{\lambda}^n = \log \lambda^n + \log M^n$。帕累托权重 $\lambda^n$ 按 $d\log \lambda_t^n = -\nu_t^n \, dt$ 演化，而 $\log M_t^n$ 由 {eq}`eq:radon_nikodym` 给出。
+```
+
+```{solution-start} ex_modified_discount
+:class: dropdown
+```
+
+由定义 $\tilde{\lambda}^n = \lambda^n M^n$，我们有
+
+$$
+\log \tilde{\lambda}_t^n = \log \lambda_t^n + \log M_t^n.
+$$
+
+帕累托权重满足 $d\log \lambda_t^n = -\nu_t^n \, dt$。
+
+由 {eq}`eq:radon_nikodym`，$\log M_t^n = -\frac{1}{2}|\omega^n|^2 t + \omega^n W_t$，因此
+
+$$
+d \log M_t^n = -\tfrac{1}{2}(\omega^n)^2 \, dt + \omega^n \, dW_t.
+$$
+
+将两者相加：
+
+$$
+d \log \tilde{\lambda}_t^n = -\nu_t^n \, dt - \tfrac{1}{2}(\omega^n)^2 \, dt + \omega^n \, dW_t = -\left(\nu_t^n + \tfrac{1}{2}(\omega^n)^2\right) dt + \omega^n \, dW_t.
+$$
+
+```{solution-end}
+```
+
+### 状态变量：帕累托份额
+
+关键的状态变量是主体 1 的帕累托份额：
+
+$$
+\upsilon = \frac{\tilde{\lambda}^1}{\tilde{\lambda}^1 + \tilde{\lambda}^2} \in (0, 1)
+$$ (eq:pareto_share)
+
+它刻画了主体 1 在规划者配置中的相对权重。
+
+定义对数几率比 $\vartheta = \log(\upsilon / (1 - \upsilon))$。
+
+其动态为
+
+$$
+d\vartheta_t = \underbrace{\left[\nu_t^2 + \frac{1}{2}(\omega^2)^2 - \nu_t^1 - \frac{1}{2}(\omega^1)^2\right]}_{m_{\vartheta}(\upsilon_t)} dt + (\omega^1 - \omega^2) dW_t
+$$ (eq:log_odds)
+
+漂移 $m_\vartheta(\upsilon)$ 决定了帕累托份额的长期行为。
+
+```{exercise}
+:label: ex_log_odds
+
+从 {eq}`eq:modified_discount` 和定义 $\vartheta = \log(\upsilon/(1-\upsilon))$ 推导 {eq}`eq:log_odds`。
+
+*提示：* 首先证明 $\vartheta = \log \tilde{\lambda}^1 - \log \tilde{\lambda}^2$，然后将两个 SDE 相减。
+```
+
+```{solution-start} ex_log_odds
+:class: dropdown
+```
+
+由于 $\upsilon = \tilde{\lambda}^1 / (\tilde{\lambda}^1 + \tilde{\lambda}^2)$，我们有 $1 - \upsilon = \tilde{\lambda}^2 / (\tilde{\lambda}^1 + \tilde{\lambda}^2)$，因此
+
+$$
+\vartheta = \log\frac{\upsilon}{1-\upsilon} = \log \tilde{\lambda}^1 - \log \tilde{\lambda}^2.
+$$
+
+由 {eq}`eq:modified_discount`，两个对数贴现因子的 SDE 为
+
+$$
+d\log \tilde{\lambda}^1_t = -\left(\nu_t^1 + \tfrac{1}{2}(\omega^1)^2\right)dt + \omega^1 dW_t,
+$$
+
+$$
+d\log \tilde{\lambda}^2_t = -\left(\nu_t^2 + \tfrac{1}{2}(\omega^2)^2\right)dt + \omega^2 dW_t.
+$$
+
+用第一个减去第二个：
+
+$$
+d\vartheta_t = \left[\nu_t^2 + \tfrac{1}{2}(\omega^2)^2 - \nu_t^1 - \tfrac{1}{2}(\omega^1)^2\right]dt + (\omega^1 - \omega^2)dW_t.
+$$
+
+```{solution-end}
+```
+
+### HJB 方程
+
+齐次性将规划者问题简化为关于单一状态变量 $\upsilon$ 的非线性 ODE。
+
+因为每个主体的效用关于消费是 $1-\gamma$ 次齐次的，规划者的值函数可以分解为 $J(\upsilon, Y) = \tilde{J}(\upsilon) \cdot Y^{1-\gamma}/(1-\gamma)$，从而消除了 $Y$ 作为状态变量。
+
+#### 从离散时间到连续时间
+
+在离散时间中，规划者通过在每个日期选择配置来最大化主体效用的加权和。
+
+贝尔曼方程为
+
+$$
+\tilde{J}(\upsilon) = \max_{z^1, z^2} \left\{ \upsilon \, u(z^1) + (1-\upsilon) \, u(z^2) + \beta \, \mathbb{E}\left[\tilde{J}(\upsilon')\right] \right\}.
+$$
+
+在连续时间中，时期长度缩小为 $dt$。
+
+$[t, t+dt)$ 上的"流量收益"变为 $\left[\upsilon F(z^1, \nu^1) + (1-\upsilon)F(z^2, \nu^2)\right] dt$，其中 $F$ 是 Duffie-Epstein-Zin 幸福函数 {eq}`eq:felicity`。
+
+值函数在 $dt$ 上的期望变化由**无穷小生成元** $\mathcal{L}$ 捕获。
+
+对于扩散过程 $d\upsilon = m \, dt + s \, dW$，伊藤引理给出
+
+$$
+\mathcal{L}\tilde{J}(\upsilon) = m(\upsilon)\,\tilde{J}'(\upsilon) + \tfrac{1}{2} s(\upsilon)^2 \, \tilde{J}''(\upsilon),
+$$
+
+其中 $m$ 和 $s$ 是帕累托份额的漂移和扩散。
+
+这是 $\beta \, \mathbb{E}[\tilde{J}(\upsilon')] - \tilde{J}(\upsilon)$ 的连续时间类比：它衡量随着 $\upsilon$ 演化，值函数如何漂移和波动。
+
+令流量收益加上期望资本收益等于零，得到示意性的 HJB 方程：
+
+$$
+0 = \sup_{(z^1,z^2,\nu^1,\nu^2)} \left\{ \upsilon F(z^1, \nu^1) + (1-\upsilon) F(z^2, \nu^2) + \mathcal{L} \tilde{J}(\upsilon) \right\}
+$$ (eq:hjb_sketch)
+
+满足约束 $z^1 + z^2 \leq 1$。
+
+#### 精确的约化 ODE
+
+{cite:t}`Borovicka2020` 的命题 2.3 在代入齐次性约化 $J(\tilde{\lambda}, Y) = (\tilde{\lambda}^1 + \tilde{\lambda}^2) Y^{1-\gamma} \tilde{J}(\upsilon)$ 以及 $\upsilon$ 和 $Y$ 的动态后，给出了精确的 HJB 方程：
+
+$$
+0 = \sup_{(z^1, z^2, \nu^1, \nu^2)} \;
+\upsilon \, F(z^1, \nu^1) + (1 - \upsilon) \, F(z^2, \nu^2)
+$$ (eq:hjb)
+
+$$
++ \left[
+-\upsilon \nu^1 - (1-\upsilon)\nu^2
++ \bigl(\upsilon \omega^1 + (1-\upsilon)\omega^2\bigr)(1-\gamma)\sigma_Y
++ (1-\gamma)\mu_Y
++ \tfrac{1}{2}(1-\gamma)^2 \sigma_Y^2
+\right] \tilde{J}(\upsilon)
+$$
+
+$$
++ \upsilon(1-\upsilon)
+\left[\nu^2 - \nu^1 + (\omega^1 - \omega^2)(1-\gamma)\sigma_Y\right]
+\tilde{J}'(\upsilon)
+$$
+
+$$
++ \tfrac{1}{2}\upsilon^2(1-\upsilon)^2 (\omega^1 - \omega^2)^2 \,
+\tilde{J}''(\upsilon)
+$$
+
+满足约束 $z^1 + z^2 \leq 1$。
+
+第一行是来自两个主体幸福函数的流量收益。
+
+第二行将 $\tilde{J}(\upsilon)$ 乘以一个结合了主体贴现率、信念加权的禀赋漂移以及方差修正的项——这些来自于通过伊藤引理吸收 $Y^{1-\gamma}$ 因子。
+
+第三行将 $\tilde{J}'(\upsilon)$ 乘以帕累托份额的漂移，它取决于贴现率的差异以及对禀赋风险的信念加权响应。
+
+第四行将 $\tilde{J}''(\upsilon)$ 乘以帕累托份额扩散的平方。
+
+边界条件为 $\tilde{J}(0) = \tilde{V}^2$ 和 $\tilde{J}(1) = \tilde{V}^1$，其中 $\tilde{V}^n$ 是仅由主体 $n$ 单独构成的齐次经济体中的延续值。
+
+这是 {cite:t}`Blume_Easley2006` 中离散时间规划者问题的连续时间对应(另见 {doc}`likelihood_ratio_process_2`)。
+
+
+## 生存条件
+
+核心结果通过 $m_\vartheta(\upsilon)$ 的边界行为来刻画生存。
+
+```{prf:proposition}
+:label: survival_conditions
+
+定义以下排斥条件 (i) 和 (ii) 及其吸引对应条件 (i') 和 (ii')：
+
+$$
+\text{(i)} \lim_{\upsilon \searrow 0} m_\vartheta(\upsilon) > 0, \qquad
+\text{(i')} \lim_{\upsilon \searrow 0} m_\vartheta(\upsilon) < 0
+$$
+
+$$
+\text{(ii)} \lim_{\upsilon \nearrow 1} m_\vartheta(\upsilon) < 0, \qquad
+\text{(ii')} \lim_{\upsilon \nearrow 1} m_\vartheta(\upsilon) > 0
+$$
+
+那么：
+
+*(a)* 若 (i) 和 (ii) 成立，则两个主体在 $P$ 下都生存。
+
+*(b)* 若 (i) 和 (ii') 成立，则主体 1 在 $P$ 下长期占据主导地位。
+
+*(c)* 若 (i') 和 (ii) 成立，则主体 2 在 $P$ 下长期占据主导地位。
+
+*(d)* 若 (i') 和 (ii') 成立，则每个主体都以严格正概率占据主导地位。
+```
+
+该证明使用了扩散过程边界行为的 Feller 分类，如 {cite:t}`Karlin_Taylor1981` 所述。
+
+条件 (i) 表明，当主体 1 接近消亡时，存在一种将其份额推回上升的力量。
+
+条件 (ii) 表明，当主体 1 接近吸收整个经济体时，存在一种将其份额推回下降的力量。
+
+当两种力量都存在时，帕累托份额是常返的，两个主体都生存。
+
+## 财富动态分解
+
+我们现在用均衡财富动态重写 {prf:ref}`survival_conditions` 中的生存条件。
+
+当且仅当主体 1 在其规模微不足道时财富增长快于主体 2，主体 1 才能在接近消亡时生存下来。
+
+当 $\upsilon \searrow 0$ 时，价格完全由主体 2 决定，仿佛经济体是齐次的。
+
+主体 1 是主体 2 经济体中的价格接受者。
+
+令 $m_A^n(\upsilon)$ 表示主体 $n$ 财富的期望对数增长率。
+
+其差异分解为两个渠道：
+
+$$
+\lim_{\upsilon \searrow 0} [m_A^1(\upsilon) - m_A^2(\upsilon)]
+= \underbrace{\lim_{\upsilon \searrow 0} [m_R^1(\upsilon) - m_R^2(\upsilon)]}_{\text{组合收益}}
++ \underbrace{\lim_{\upsilon \searrow 0} [(y^2(\upsilon))^{-1} - (y^1(\upsilon))^{-1}]}_{\text{消费-财富比}}
+$$ (eq:wealth_decomp)
+
+第一项衡量主体 1 的投资组合增长快多少。
+
+第二项衡量主体 1 从财富中消费少多少——较低的消费-财富比意味着更多的储蓄和更快的财富积累。
+
+当此总差异为正时，主体 1 生存；当为负时，她朝着消亡收缩。
+
+```{exercise}
+:label: ex_wealth_decomp
+
+推导 {eq}`eq:wealth_decomp`。
+
+令 $A^n$ 表示主体 $n$ 的财富，$C^n$ 表示她的消费。
+
+预算约束为 $dA^n = A^n dR^n - C^n dt$，其中 $dR^n$ 是主体 $n$ 投资组合的收益。
+
+定义消费-财富比 $c^n = C^n / A^n = (y^n)^{-1}$。
+
+证明 $d\log A^n = m_R^n \, dt - (y^n)^{-1} dt + \ldots$，因此期望对数财富增长之差为 $m_A^1 - m_A^2 = (m_R^1 - m_R^2) + [(y^2)^{-1} - (y^1)^{-1}]$。
+```
+
+```{solution-start} ex_wealth_decomp
+:class: dropdown
+```
+
+将预算约束除以 $A^n$：
+
+$$
+\frac{dA^n}{A^n} = dR^n - (y^n)^{-1} dt.
+$$
+
+由伊藤引理，$d\log A^n = \frac{dA^n}{A^n} - \frac{1}{2}\left(\frac{dA^n}{A^n}\right)^2$。
+
+将 $dR^n = m_R^n \, dt + \sigma_R^n \, dW$ 写出($P$ 下的投资组合收益)。
+
+那么
+
+$$
+d\log A^n = \left(m_R^n - (y^n)^{-1} - \tfrac{1}{2}(\sigma_R^n)^2\right) dt + \sigma_R^n \, dW.
+$$
+
+对主体 1 和 2 取差：
+
+$$
+m_A^1 - m_A^2 = (m_R^1 - m_R^2) + \left[(y^2)^{-1} - (y^1)^{-1}\right] - \tfrac{1}{2}\left[(\sigma_R^1)^2 - (\sigma_R^2)^2\right].
+$$
+
+当我们将 $m_R^n$ 定义为期望对数投资组合收益(即 $\log R^n$ 的漂移而非算术收益)时，波动率项 $\tfrac{1}{2}[(\sigma_R^1)^2 - (\sigma_R^2)^2]$ 被吸收进 $m_R^1 - m_R^2$，从而得到 {eq}`eq:wealth_decomp`。
+
+```{solution-end}
+```
+
+### 组合收益
+
+在边界 $\upsilon \searrow 0$ 处，期望对数投资组合收益之差为
+
+$$
+\lim_{\upsilon \searrow 0} [m_R^1 - m_R^2]
+= \underbrace{\frac{\omega^1 - \omega^2}{\gamma \sigma_Y}}_{\text{风险份额之差}}
+\cdot \underbrace{(\gamma \sigma_Y^2 - \omega^2 \sigma_Y)}_{\text{风险溢价}}
+- \underbrace{\frac{\omega^1 - \omega^2}{\gamma}
+\left(\sigma_Y + \frac{\omega^1 - \omega^2}{2\gamma}\right)}_{\text{波动率项}}
+$$ (eq:portfolio_returns)
+
+乐观的主体($\omega^1 > \omega^2$)相对于主体 2 将风险资产超配 $(\omega^1 - \omega^2)/(\gamma \sigma_Y)$，并从这一额外敞口中赚取股权风险溢价。
+
+被减去的*波动率惩罚*反映了持有更极端投资组合的成本：对数收益率的较高方差拖累了期望对数财富增长。
+
+此项依赖于风险厌恶 $\gamma$，但不依赖于 IES，因为投资组合选择仅由风险厌恶决定。
+
+```{exercise}
+:label: ex_portfolio_returns
+
+推导 {eq}`eq:portfolio_returns`。
+
+在边界 $\upsilon \searrow 0$ 处，主体 $n$ 的最优风险资产份额为 $\pi^n = 1 + (\omega^n - \omega^2)/(\gamma \sigma_Y)$(参见 {eq}`eq:portfolio`)。
+
+令 $\bar{\mu}_R = \mu_Y + \gamma \sigma_Y^2 - \omega^2 \sigma_Y$ 表示 $P$ 下风险资产的期望收益，$r$ 表示无风险利率。
+
+连续再平衡的投资组合具有期望对数收益 $m_R^n = r + \pi^n(\bar{\mu}_R - r) - \frac{1}{2}(\pi^n)^2 \sigma_Y^2$。
+
+计算 $m_R^1 - m_R^2$ 并化简。
+```
+
+```{solution-start} ex_portfolio_returns
+:class: dropdown
+```
+
+使用 $m_R^n = r + \pi^n(\bar{\mu}_R - r) - \frac{1}{2}(\pi^n)^2 \sigma_Y^2$，差异为
+
+$$
+m_R^1 - m_R^2 = (\pi^1 - \pi^2)(\bar{\mu}_R - r) - \tfrac{1}{2}[(\pi^1)^2 - (\pi^2)^2]\sigma_Y^2.
+$$
+
+风险份额之差为 $\pi^1 - \pi^2 = (\omega^1 - \omega^2)/(\gamma \sigma_Y)$。
+
+算术股权溢价为 $\bar{\mu}_R - r = \gamma \sigma_Y^2 - \omega^2 \sigma_Y$，因此：
+
+$$
+(\pi^1 - \pi^2)(\bar{\mu}_R - r) = \frac{\omega^1 - \omega^2}{\gamma \sigma_Y} \cdot (\gamma \sigma_Y^2 - \omega^2 \sigma_Y).
+$$
+
+对于波动率项，写出 $(\pi^1)^2 - (\pi^2)^2 = (\pi^1 - \pi^2)(\pi^1 + \pi^2)$ 并注意 $\pi^1 + \pi^2 = 2 + (\omega^1 + \omega^2 - 2\omega^2)/(\gamma \sigma_Y)$。
+
+化简后：
+
+$$
+\tfrac{1}{2}[(\pi^1)^2 - (\pi^2)^2]\sigma_Y^2 = \frac{\omega^1 - \omega^2}{\gamma}\left(\sigma_Y + \frac{\omega^1 - \omega^2}{2\gamma}\right).
+$$
+
+将两部分合并即得 {eq}`eq:portfolio_returns`。
+
+```{solution-end}
+```
+
+### 消费-财富比
+
+在边界处消费-财富比之差为
+
+$$
+\lim_{\upsilon \searrow 0} [(y^2)^{-1} - (y^1)^{-1}]
+= \frac{1-\rho}{\rho} \left[(\omega^1 - \omega^2)\sigma_Y + \frac{(\omega^1 - \omega^2)^2}{2\gamma}\right]
+$$ (eq:consumption_rates)
+
+括号中的项是*主观*期望投资组合收益之差——即主体 1 相对于主体 2 认为她所赚取的收益。
+
+因子 $(1-\rho)/\rho$ 将这种感知到的收益优势转化为储蓄响应。
+
+- 当 IES $> 1$($\rho < 1$)时，因子为正：更高的感知收益使主体储蓄更多，因为替代效应主导了收入效应。
+- 当 IES $< 1$($\rho > 1$)时，因子为负：收入效应占主导，主体储蓄更少，不利于生存。
+- 当 IES $= 1$($\rho = 1$)时，两种效应相互抵消，储蓄渠道完全消失。
+
+这就是递归偏好通过将 $\gamma$ 与 $\rho$ 分离来改变生存结果的渠道。
+
+```{exercise}
+:label: ex_consumption_wealth
+
+推导 {eq}`eq:consumption_rates`。
+
+在由主体 2 构成的齐次经济体中，消费-财富比为 $(y(0))^{-1} = \beta - (1-\rho)\mu_V^2$，其中 $\mu_V^2$ 是主体 2 财富的期望对数收益。
+
+作为微不足道的价格接受者，主体 1 的消费-财富比为 $(y^1)^{-1} = \beta - (1-\rho)\mu_V^1$，其中 $\mu_V^1$ 是她自己的期望对数收益。
+
+使用 $(y^2)^{-1} - (y^1)^{-1} = (1-\rho)(\mu_V^1 - \mu_V^2)$，并用主体 1 的*主观*期望超额收益表示 $\mu_V^1 - \mu_V^2$。
+
+*提示：* 在主体 1 的信念下，她的投资组合在期望对数收益方面相对于主体 2 的投资组合多赚 $(\omega^1 - \omega^2)\sigma_Y + (\omega^1 - \omega^2)^2/(2\gamma)$。
+```
+
+```{solution-start} ex_consumption_wealth
+:class: dropdown
+```
+
+主体 $n$ 的消费-财富比满足 $(y^n)^{-1} = \beta - (1-\rho)\mu_V^n$，其中 $\mu_V^n$ 是主体 $n$ 在其自身主观测度下财富的期望对数收益。
+
+取差：
+
+$$
+(y^2)^{-1} - (y^1)^{-1} = (1-\rho)(\mu_V^1 - \mu_V^2).
+$$
+
+主体 1 的主观期望对数投资组合收益超过主体 2 的部分，等于她认为通过向风险资产倾斜所获得的收益。
+
+她额外的风险份额为 $\pi^1 - 1 = (\omega^1 - \omega^2)/(\gamma\sigma_Y)$，而在她的主观测度 $Q^1$ 下风险资产的期望超额对数收益为 $(\gamma\sigma_Y^2 + (\omega^1 - \omega^2)\sigma_Y - \omega^2\sigma_Y) - r - \frac{1}{2}\sigma_Y^2$。
+
+化简后，主观期望对数收益之差为
+
+$$
+\mu_V^1 - \mu_V^2 = (\omega^1 - \omega^2)\sigma_Y + \frac{(\omega^1 - \omega^2)^2}{2\gamma}.
+$$
+
+代入并整体除以 $\rho$(由 $(y^n)^{-1}$ 与 $\beta$ 之间的关系)：
+
+$$
+(y^2)^{-1} - (y^1)^{-1} = \frac{1-\rho}{\rho}\left[(\omega^1 - \omega^2)\sigma_Y + \frac{(\omega^1 - \omega^2)^2}{2\gamma}\right].
+$$
+
+```{solution-end}
+```
+
+### 两个比较静态分析
+
+生存取决于 $\gamma$、$\rho$ 以及信噪比 $\omega^1 / \sigma_Y$ 和 $\omega^2 / \sigma_Y$，而非分别取决于 $\omega^1$、$\omega^2$ 和 $\sigma_Y$。
+
+生存条件不依赖于 $\beta$ 或 $\mu_Y$，它们影响消费和价格的水平，但不影响边界处的相对财富动态。
+
+```{code-cell} ipython3
+def portfolio_return_diff(ω_1, ω_2, γ, σ_y):
+    """
+    边界处期望对数投资组合收益之差。
+    """
+    Δω = ω_1 - ω_2
+    risky_share_diff = Δω / (γ * σ_y)
+    risk_premium = γ * σ_y**2 - ω_2 * σ_y
+    volatility_term = (Δω / γ) * (σ_y + 0.5 * Δω / γ)
+    return risky_share_diff * risk_premium - volatility_term
+
+
+def saving_channel(ω_1, ω_2, γ, ρ, σ_y):
+    """
+    边界处消费-财富比之差。
+    """
+    Δω = ω_1 - ω_2
+    subjective_return_diff = Δω * σ_y + Δω**2 / (2 * γ)
+    return (1 - ρ) / ρ * subjective_return_diff
+
+
+def boundary_drift(ω_1, ω_2, γ, ρ, σ_y):
+    """
+    当主体 1 变得微不足道时的边界漂移 m_ϑ。
+
+    正漂移意味着主体 1 生存(排斥边界)。
+    """
+    return γ * (
+        portfolio_return_diff(ω_1, ω_2, γ, σ_y)
+        + saving_channel(ω_1, ω_2, γ, ρ, σ_y)
+    )
+```
+
+## 生存区域
+
+{cite:t}`Borovicka2020` 的一个核心贡献是刻画了 $(\gamma, \rho)$ 平面中的生存区域。
+
+在可分偏好下，$\gamma = \rho$，信念更准确的主体总是占据主导地位。
+
+在递归偏好下，{prf:ref}`survival_conditions` 中的所有四种结果都可能出现。
+
+文中的图 2 研究了主体 2 具有正确信念的情形，即 $\omega^2 = 0$。
+
+下一个单元遵循该图。
+
+```{code-cell} ipython3
+def compute_survival_boundary(ω_1, ω_2, σ_y, γ_grid, boundary="lower"):
+    """
+    计算 (γ, ρ) 空间中边界漂移为零的曲线。
+
+    对于 boundary='lower'，主体 1 是小主体。
+    对于 boundary='upper'，主体 2 是小主体。
+    """
+    ρ_boundary = []
+
+    if boundary == "lower":
+        small_agent = (ω_1, ω_2)
+    else:
+        small_agent = (ω_2, ω_1)
+
+    ω_small, ω_large = small_agent
+
+    for γ in γ_grid:
+        pr = portfolio_return_diff(ω_small, ω_large, γ, σ_y)
+        Δω = ω_small - ω_large
+        subj_ret = Δω * σ_y + Δω**2 / (2 * γ)
+
+        if abs(subj_ret) < 1e-14:
+            ρ_boundary.append(np.nan)
+            continue
+
+        denom = subj_ret - pr
+        if abs(denom) < 1e-14:
+            ρ_boundary.append(np.nan)
+        else:
+            ρ_boundary.append(subj_ret / denom)
+
+    return np.asarray(ρ_boundary)
+
+
+def compute_limit_boundary(γ_grid, boundary="lower"):
+    """
+    极限 |ω_1| / σ_y -> ∞ 的边界曲线。
+
+    这等价于文中讨论的常数禀赋情形。
+    """
+    if boundary == "lower":
+        return γ_grid / (1 + γ_grid)
+
+    ρ = np.full_like(γ_grid, np.nan, dtype=float)
+    mask = γ_grid < 1
+    ρ[mask] = γ_grid[mask] / (1 - γ_grid[mask])
+    return ρ
+```
+
+```{code-cell} ipython3
+---
+tags: [hide-input]
+mystnb:
+  figure:
+    caption: 对应于 Borovicka (2020) 图 2 的生存区域
+    name: fig-survival-regions
+---
+σ_y = 0.02
+γ_vals = np.linspace(0.01, 6.0, 500)
+ρ_vals = np.linspace(0.01, 2.0, 400)
+G, R = np.meshgrid(γ_vals, ρ_vals)
+
+panel_specs = [
+    ("finite", 0.10, r"$\omega^1 = 0.10$"),
+    ("finite", 0.20, r"$\omega^1 = 0.20$"),
+    ("limit", None, r"$|\omega^1| / \sigma_Y \to \infty$"),
+    ("finite", -0.25, r"$\omega^1 = -0.25$"),
+]
+
+fig, axes = plt.subplots(2, 2, figsize=(13, 10), sharex=True, sharey=True)
+
+for idx, (case, value, label) in enumerate(panel_specs):
+    ax = axes.flat[idx]
+
+    if case == "limit":
+        ρ_1 = compute_limit_boundary(γ_vals, boundary="lower")
+        ρ_2 = compute_limit_boundary(γ_vals, boundary="upper")
+        # 极限边界漂移：使用闭式表达式
+        # 当 ρ < γ/(1+γ) 时 m0 > 0(主体 1 生存)
+        m0 = G - (1 + G) * R
+        # 当 γ<1 时 ρ < γ/(1-γ) 时 m1 < 0(主体 2 生存)，γ>=1 时总成立
+        m1 = (1 - G) * R - G
+    else:
+        ρ_1 = compute_survival_boundary(value, 0.0, σ_y, γ_vals,
+                                        boundary="lower")
+        ρ_2 = compute_survival_boundary(value, 0.0, σ_y, γ_vals,
+                                        boundary="upper")
+        # 在网格上评估边界漂移
+        m0 = boundary_drift(value, 0.0, G, R, σ_y)
+        m1 = -boundary_drift(0.0, value, G, R, σ_y)
+
+    # 对所有四个区域进行分类
+    both = (m0 > 0) & (m1 < 0)
+    ag1_dom = (m0 > 0) & (m1 > 0)
+    ag2_dom = (m0 < 0) & (m1 < 0)
+    either = (m0 < 0) & (m1 > 0)
+
+    # 对共存区域着色
+    ax.contourf(G, R, both.astype(float), levels=[0.5, 1.5],
+                colors=["C2"], alpha=0.18)
+    if idx == 0:
+        ax.fill_between([], [], color="C2", alpha=0.18,
+                        label="两者都生存")
+
+    # 绘制边界曲线
+    ax.contour(G, R, m0, levels=[0], colors=["C0"],
+               linestyles="--", linewidths=2)
+    ax.contour(G, R, m1, levels=[0], colors=["C3"],
+               linestyles="-", linewidths=2)
+    if idx == 0:
+        ax.plot([], [], "--", color="C0", lw=2, label="主体 1 边界")
+        ax.plot([], [], "-", color="C3", lw=2, label="主体 2 边界")
+
+    ax.plot(
+        γ_vals, γ_vals, ":", color="black", lw=2,
+        label=r"$\gamma = \rho$" if idx == 0 else None
+    )
+
+    tkw = dict(ha="center", va="center", style="italic", color="0.15")
+    if case == "finite" and value == 0.10:
+        ax.text(0.31, 1.05, "任一主体占主导", rotation=90,
+                fontsize=10, **tkw)
+        ax.text(1.8, 1.55, "主体 2\n占主导", fontsize=11, **tkw)
+        ax.text(3.5, 0.75, "两者\n都生存", fontsize=11, **tkw)
+        if ag1_dom.any():
+            ax.text(5.0, 0.25, "主体 1\n占主导", fontsize=11, **tkw)
+    elif case == "finite" and value == 0.20:
+        ax.text(0.31, 1.05, "任一主体占主导", rotation=90,
+                fontsize=10, **tkw)
+        ax.text(2.5, 1.55, "主体 2\n占主导", fontsize=11, **tkw)
+        ax.text(3.8, 0.55, "两者\n都生存", fontsize=11, **tkw)
+        if ag1_dom.any():
+            ax.text(5.2, 0.08, "主体 1\n占主导", fontsize=9, **tkw)
+    elif case == "limit":
+        ax.text(0.31, 1.05, "任一主体占主导", rotation=90,
+                fontsize=10, **tkw)
+        ax.text(3.0, 1.40, "主体 2\n占主导", fontsize=11, **tkw)
+        ax.text(3.5, 0.30, "两者\n都生存", fontsize=11, **tkw)
+    elif case == "finite" and value == -0.25:
+        ax.text(0.31, 1.05, "任一主体占主导", rotation=90,
+                fontsize=10, **tkw)
+        ax.text(3.5, 1.20, "主体 2\n占主导", fontsize=11, **tkw)
+        ax.text(2.5, 0.18, "两者\n都生存", fontsize=11, **tkw)
+
+    ax.set_title(label, fontsize=12)
+    ax.set_xlim(0, 6)
+    ax.set_ylim(0, 2)
+    ax.set_xlabel(r"$\gamma$")
+    ax.set_ylabel(r"$\rho$")
+
+axes[0, 0].legend(loc="upper left", fontsize=9)
+plt.tight_layout()
+plt.show()
+```
+
+每个面板针对主体 1 的信念扭曲 $\omega^1$ 的不同取值(主体 2 具有正确信念，$\omega^2 = 0$)绘制 $(\gamma, \rho)$ 平面中的两条曲线。
+
+- 虚线(蓝色)是 $\upsilon = 0$ 处边界漂移等于零的地方——{prf:ref}`survival_conditions` 中的条件 (i)。
+- 实线(红色)是 $\upsilon = 1$ 处边界漂移等于零的地方——条件 (ii)。
+- 两条曲线之间的阴影区域是两个主体都生存的地方。
+- 虚线对角线 $\gamma = \rho$ 是可分 CRRA 情形，沿此线信念更准确的主体总是占据主导地位。
+
+适度乐观($\omega^1 = 0.10$)产生了一个宽阔的共存区域，横跨大部分 $\gamma$ 范围。
+
+较强的乐观($\omega^1 = 0.20$)缩小了该区域：主体 2 边界对于中等和较大的 $\gamma$ 移出了绘图范围，缩小了两个主体共存的 $(\gamma, \rho)$ 对的集合。
+
+在极限 $|\omega^1|/\sigma_Y \to \infty$(左下)中，边界简化为闭式表达式。
+
+共存区域变窄，但在主体 2 边界曲线下方延伸到较大的 $\gamma$ 值。
+
+悲观的扭曲($\omega^1 = -0.25$，右下)也可以生存，但仅在参数空间中窄得多的部分。
+
+## 三个生存渠道
+
+上述分解可以直接可视化。
+
+```{code-cell} ipython3
+def decompose_survival(ω_1, ω_2, γ_grid, ρ, σ_y):
+    """
+    分解命题 3.4 中的财富增长差异。
+    """
+    Δω = ω_1 - ω_2
+    risk_premium_term = Δω * (γ_grid * σ_y - ω_2) / γ_grid
+    volatility_term = -(Δω / γ_grid) * (σ_y + 0.5 * Δω / γ_grid)
+    saving_term = (1 - ρ) / ρ * (Δω * σ_y + Δω**2 / (2 * γ_grid))
+    total = risk_premium_term + volatility_term + saving_term
+    return risk_premium_term, volatility_term, saving_term, total
+
+
+ω_1 = 0.25
+ω_2 = 0.0
+ρ = 0.67
+σ_y = 0.02
+γ_grid = np.linspace(0.5, 15.0, 300)
+
+risk_term, vol_term, save_term, total = decompose_survival(
+    ω_1, ω_2, γ_grid, ρ, σ_y
+)
+
+fig, ax = plt.subplots(figsize=(11, 6))
+ax.plot(γ_grid, risk_term, color="C0", lw=2, label="风险溢价项")
+ax.plot(γ_grid, vol_term, "--", color="C3", lw=2, label="波动率项")
+ax.plot(γ_grid, save_term, "-.", color="C2", lw=2, label="储蓄项")
+ax.plot(γ_grid, total, color="black", lw=2, label="总计")
+ax.axhline(0, color="gray", lw=1)
+ax.set_xlabel(r"风险厌恶 $\gamma$")
+ax.set_ylabel("对财富增长差异的贡献")
+ax.legend()
+plt.tight_layout()
+plt.show()
+```
+
+此图将 $\upsilon = 0$ 处的边界漂移分解为三项，针对一个乐观主体($\omega^1 = {0.25}$，$\omega^2 = 0$)，其 IES $= 1/\rho \approx 1.49$，$\sigma_Y = 0.02$。
+
+- 风险溢价项(蓝色)始终为正，因为乐观主体超配了风险资产并赚取了股权溢价。
+- 波动率项(红色虚线)为负且在低 $\gamma$ 时较大，反映了持有波动投资组合的成本。
+- 储蓄项(绿色点划线)在 IES $> 1$ 时为正，因为乐观主体感知到财富的高收益并更激进地储蓄。
+- 总计(黑色)在临界 $\gamma$ 处穿过零点，低于此值波动率惩罚占主导，主体无法生存。
+
+## 改变 IES
+
+储蓄项的符号由 IES 确定。
+
+```{code-cell} ipython3
+---
+mystnb:
+  figure:
+    caption: 不同 IES 值的边界分解
+    name: fig-survival-ies-panels
+---
+fig, axes = plt.subplots(1, 3, figsize=(16, 4.5), sharey=True)
+
+ω_1 = 0.25
+ω_2 = 0.0
+σ_y = 0.02
+γ_grid = np.linspace(0.5, 25.0, 300)
+
+ies_values = [0.5, 1.0, 1.5]
+
+for idx, ies in enumerate(ies_values):
+    ρ = 1.0 / ies
+    risk_term, vol_term, save_term, total = decompose_survival(
+        ω_1, ω_2, γ_grid, ρ, σ_y
+    )
+
+    ax = axes[idx]
+    ax.plot(γ_grid, risk_term, color="C0", lw=2, label="风险溢价")
+    ax.plot(γ_grid, vol_term, "--", color="C3", lw=2, label="波动率")
+    ax.plot(γ_grid, save_term, "-.", color="C2", lw=2, label="储蓄")
+    ax.plot(γ_grid, total, color="black", lw=2, label="总计")
+    ax.axhline(0, color="gray", lw=1)
+    ax.set_title(f"IES = {ies:.1f}", fontsize=12)
+    ax.set_xlabel(r"风险厌恶 $\gamma$")
+    ax.set_ylabel("贡献")
+
+axes[0].legend(fontsize=9)
+plt.tight_layout()
+plt.show()
+```
+
+每个面板显示与前一图相同的三项分解，但现在针对三种不同的 IES 值($\omega^1 = 0.25$，$\omega^2 = 0$，$\sigma_Y = 0.02$)。
+
+- 左面板(IES $= 0.5$)：储蓄项为负，因此乐观主体实际上储蓄更少，不利于生存。
+- 中面板(IES $= 1.0$)：储蓄项完全消失，因此只剩下投资组合收益和波动率渠道。
+
+    - 这消除了储蓄渠道，但本身并不能重现完整的可分 CRRA 基准，后者要求 $\gamma = \rho$(即 IES $= 1/\gamma$)，而不仅仅是 $\rho = 1$。
+- 右面板(IES $= 1.5$)：储蓄项为正并将总漂移向上移动，扩大了乐观主体生存的 $\gamma$ 值范围。
+
+## 渐近结果
+
+Borovicka 推导了几个有用的渐近结果。
+
+1. 当 $\gamma \searrow 0$ 时，每个主体都以严格正概率占据主导地位。
+1. 当 $\gamma \nearrow \infty$ 时，相对更乐观的主体占据主导地位。
+1. 当 $\rho \searrow 0$ 时，相对更乐观的主体总是生存。
+   - 当风险厌恶足够低时，相对更悲观的主体也可以生存。
+1. 当 $\rho \nearrow \infty$ 时，非退化的长期均衡不可能存在。
+
+下一个图通过绘制 $\gamma$ 变小时的两个边界漂移来说明第一个结果。
+
+```{code-cell} ipython3
+---
+mystnb:
+  figure:
+    caption: 小风险厌恶下的边界漂移
+    name: fig-boundary-drifts-small-gamma
+---
+ω_1 = 0.25
+ω_2 = 0.0
+ρ = 0.67
+σ_y = 0.02
+γ_grid = np.linspace(0.05, 5.0, 300)
+
+drift_at_0 = np.array([boundary_drift(ω_1, ω_2, γ, ρ, σ_y) for γ in γ_grid])
+drift_at_1 = np.array([-boundary_drift(ω_2, ω_1, γ, ρ, σ_y) for γ in γ_grid])
+
+fig, ax = plt.subplots(figsize=(10, 5))
+ax.plot(γ_grid, drift_at_0, color="C0", lw=2, label=r"$\upsilon \to 0$")
+ax.plot(γ_grid, drift_at_1, "--", color="C3", lw=2, label=r"$\upsilon \to 1$")
+ax.axhline(0, color="gray", lw=1)
+ax.set_xlabel(r"风险厌恶 $\gamma$")
+ax.set_ylabel("边界漂移")
+ax.legend()
+plt.tight_layout()
+plt.show()
+```
+
+此图将两个边界漂移绘制为 $\gamma$ 的函数($\omega^1 = 0.25$，$\omega^2 = 0$，IES $\approx 1.49$)。
+
+- 实线蓝色曲线是 $\upsilon \to 0$ 处的漂移 $m_\vartheta$(主体 1 接近消亡)；共存要求这为正(条件 (i))。
+- 虚线红色曲线是 $\upsilon \to 1$ 处的漂移 $m_\vartheta$(主体 2 接近消亡)；共存要求这为负(条件 (ii))。
+
+此图说明了渐近结果 1。
+
+对于小 $\gamma$，蓝色曲线为负，红色曲线为正。
+
+两个边界都是吸引的：在 $\upsilon = 0$ 附近负漂移将 $\upsilon$ 拉向 0，在 $\upsilon = 1$ 附近正漂移将 $\upsilon$ 推向 1。
+
+这是 {prf:ref}`survival_conditions` 中的结果 (d)：两个边界都不是排斥的，因此无论哪个主体碰巧早期领先都将占据主导地位，每个主体都有严格正概率占据主导地位，这取决于实现的布朗路径。
+
+随着 $\gamma$ 增大超过大约 1，蓝色曲线穿过零点变为正，而红色曲线保持为负。
+
+现在两个边界都是排斥的，我们进入共存区域——结果 (a)。
+
+## 可分情形
+
+当 $\gamma = \rho$ 时，模型退化为可分 CRRA 基准。
+
+在这种情形下，对数几率过程变为
+
+$$
+d\vartheta_t = \frac{1}{2}\left[(\omega^2)^2 - (\omega^1)^2\right] dt + (\omega^1 - \omega^2) dW_t .
+$$
+
+漂移是常数，且仅取决于两个信念扭曲的相对熵。
+
+$|\omega^n|$ 较小的主体在 $P$ 下占据主导地位。
+
+如果两个主体的信念扭曲幅度相等，则几乎必然没有一个主体会消亡，但不存在非退化的平稳财富分布。
+
+```{code-cell} ipython3
+---
+mystnb:
+  figure:
+    caption: 可分基准中的帕累托份额路径
+    name: fig-crra-pareto-paths
+---
+def simulate_crra_pareto(ω_1, ω_2, T, dt, n_paths, seed=42):
+    """
+    模拟可分基准中的帕累托份额动态。
+    """
+    rng = np.random.default_rng(seed)
+    n_steps = int(T / dt)
+    t_grid = np.linspace(0, T, n_steps + 1)
+
+    drift = 0.5 * (ω_2**2 - ω_1**2)
+    volatility = ω_1 - ω_2
+
+    θ = np.zeros((n_paths, n_steps + 1))
+    dW = rng.normal(0.0, np.sqrt(dt), size=(n_paths, n_steps))
+
+    for t in range(n_steps):
+        θ[:, t + 1] = θ[:, t] + drift * dt + volatility * dW[:, t]
+
+    υ_paths = 1.0 / (1.0 + np.exp(-θ))
+    return t_grid, υ_paths
+
+
+ω_1 = 0.10
+ω_2 = 0.0
+t_grid, υ_paths = simulate_crra_pareto(ω_1, ω_2, T=200, dt=0.01, n_paths=50)
+
+fig, ax = plt.subplots(figsize=(11, 5))
+
+for i in range(20):
+    ax.plot(t_grid, υ_paths[i], color="C0", alpha=0.25, lw=1)
+
+ax.axhline(0.5, color="gray", linestyle=":", lw=1)
+ax.set_xlabel("时间")
+ax.set_ylabel(r"帕累托份额 $\upsilon_t$")
+ax.set_ylim(0, 1)
+plt.tight_layout()
+plt.show()
+```
+
+此图模拟了在可分 CRRA 偏好($\gamma = \rho$)下帕累托份额 $\upsilon_t$ 的 20 条样本路径，其中 $\omega^1 = 0.10$ 且 $\omega^2 = 0$。
+
+主体 2 具有正确信念，因此对数几率漂移为负，所有路径都趋向于 $\upsilon = 0$。
+
+主体 1 被驱向消亡——这是 {cite:t}`Blume_Easley2006` 的经典市场选择结果。
+
+## 资产定价含义
+
+随着一个主体变得微不足道，当前价格收敛于由大主体构成的齐次经济体的价格。
+
+当主体 2 是大主体时，{cite:t}`Borovicka2020` 中的命题 5.1 意味着
+
+$$
+\lim_{\upsilon \searrow 0} r(\upsilon)
+= \beta + \rho \left(\mu_Y + \omega^2 \sigma_Y
++ \frac{1}{2} (1 - \gamma) \sigma_Y^2\right)
+- \frac{1}{2} \gamma \sigma_Y^2
+$$ (eq:riskfree)
+
+以及
+
+$$
+\lim_{\upsilon \searrow 0} y(\upsilon)
+= \left[
+\beta - (1 - \rho)
+\left(
+\mu_Y + \omega^2 \sigma_Y + \frac{1}{2} (1 - \gamma) \sigma_Y^2
+\right)
+\right]^{-1} .
+$$ (eq:wc_ratio)
+
+总财富动态也收敛于齐次经济体的动态：
+
+$$
+\lim_{\upsilon \searrow 0} m_A(\upsilon) = \mu_Y,
+\qquad
+\lim_{\upsilon \searrow 0} \sigma_A(\upsilon) = \sigma_Y .
+$$
+
+命题 5.3 随后给出了微不足道主体自己的消费-储蓄和投资组合选择。
+
+她的消费-财富比收敛于
+
+$$
+\lim_{\upsilon \searrow 0} (y^1(\upsilon))^{-1}
+= (y(0))^{-1}
+- \frac{1-\rho}{\rho}
+\left[
+(\omega^1 - \omega^2)\sigma_Y
++ \frac{(\omega^1 - \omega^2)^2}{2 \gamma}
+\right] .
+$$
+
+小主体的风险资产份额收敛于
+
+$$
+\lim_{\upsilon \searrow 0} \pi^1(\upsilon)
+= 1 + \frac{\omega^1 - \omega^2}{\gamma \sigma_Y} .
+$$ (eq:portfolio)
+
+因此乐观意味着杠杆，而足够强的悲观意味着做空。
+
+```{code-cell} ipython3
+---
+mystnb:
+  figure:
+    caption: 小主体的极限风险资产份额
+    name: fig-limiting-portfolio-shares
+---
+ω_2 = 0.0
+σ_y = 0.02
+ω_grid = np.linspace(-0.5, 1.0, 300)
+
+fig, ax = plt.subplots(figsize=(10, 5))
+
+for γ in [2, 5, 10, 20]:
+    π_1 = 1 + (ω_grid - ω_2) / (γ * σ_y)
+    ax.plot(ω_grid, π_1, lw=2, label=rf"$\gamma = {γ}$")
+
+ax.axhline(1.0, color="gray", linestyle=":", lw=1)
+ax.axhline(0.0, color="gray", linestyle=":", lw=1)
+ax.axvline(0.0, color="gray", linestyle=":", lw=1)
+ax.set_xlabel(r"信念扭曲 $\omega^1$")
+ax.set_ylabel(r"风险份额 $\pi^1$")
+ax.legend()
+plt.tight_layout()
+plt.show()
+```
+
+此图将微不足道主体的极限风险资产份额 $\pi^1$ 绘制为她的信念扭曲 $\omega^1$ 的函数($\omega^2 = 0$，$\sigma_Y = 0.02$)，针对四个风险厌恶水平。
+
+在 $\omega^1 = 0$ 处，主体与主体 2 意见一致并持有市场投资组合($\pi^1 = 1$)。
+
+乐观($\omega^1 > 0$)导致杠杆($\pi^1 > 1$)，而足够的悲观($\omega^1 < 0$)导致做空($\pi^1 < 0$)。
+
+较高的风险厌恶将这些偏离压缩至接近 1。
+
+## 乐观和悲观扭曲
+
+乐观和悲观信念对生存的影响是不对称的。
+
+乐观主体从风险溢价项中获益，并且当 IES $> 1$ 时，也从储蓄项中获益。
+
+悲观主体放弃了风险溢价，只有当储蓄效应足够强以抵消该损失时才能生存。
+
+```{code-cell} ipython3
+---
+mystnb:
+  figure:
+    caption: 乐观和悲观扭曲的总边界漂移
+    name: fig-optimistic-pessimistic-drifts
+---
+fig, axes = plt.subplots(1, 2, figsize=(14, 5), sharey=True)
+
+σ_y = 0.02
+ω_2 = 0.0
+ρ = 0.67
+γ_grid = np.linspace(0.5, 25.0, 300)
+
+ax = axes[0]
+for ω_1 in [0.1, 0.25, 0.5, 1.0]:
+    _, _, _, total = decompose_survival(ω_1, ω_2, γ_grid, ρ, σ_y)
+    ax.plot(γ_grid, total, lw=2, label=rf"$\omega^1 = {ω_1}$")
+ax.axhline(0, color="gray", lw=1)
+ax.set_title("乐观", fontsize=12)
+ax.set_xlabel(r"风险厌恶 $\gamma$")
+ax.set_ylabel("边界漂移")
+ax.legend(fontsize=9)
+
+ax = axes[1]
+for ω_1 in [-0.1, -0.25, -0.5, -1.0]:
+    _, _, _, total = decompose_survival(ω_1, ω_2, γ_grid, ρ, σ_y)
+    ax.plot(γ_grid, total, lw=2, label=rf"$\omega^1 = {ω_1}$")
+ax.axhline(0, color="gray", lw=1)
+ax.set_title("悲观", fontsize=12)
+ax.set_xlabel(r"风险厌恶 $\gamma$")
+ax.legend(fontsize=9)
+
+plt.tight_layout()
+plt.show()
+```
+
+两个面板都将 $\upsilon = 0$ 处的总边界漂移绘制为 $\gamma$ 的函数(IES $\approx 1.49$，$\omega^2 = 0$)。
+
+曲线为正的地方，主体 1 在接近消亡时生存。
+
+- 左面板(乐观主体)：较大的 $\omega^1$ 意味着对风险资产更大的押注，因此波动率惩罚在低 $\gamma$ 时占主导，但一旦 $\gamma$ 足够大漂移转为正。
+- 右面板(悲观主体)：悲观主体通过低配风险资产放弃了风险溢价，因此漂移在大部分参数空间内为负，生存需要足够强的储蓄动机以抵消投资组合损失。
+
+## 长期消费分布
+
+当两个主体都生存时，帕累托份额持续在整个区间 $(0, 1)$ 中移动。
+
+下一个模拟只是一个玩具近似。
+
+它在两个边界值之间插值漂移，因此在不求解完整均衡 ODE 的情况下说明了常返逻辑。
+
+```{code-cell} ipython3
+---
+mystnb:
+  figure:
+    caption: 一个玩具平稳帕累托份额模拟
+    name: fig-toy-stationary-pareto-share
+---
+def simulate_pareto_share_toy(ω_1, ω_2, γ, ρ, σ_y, T, dt, n_paths=20, seed=42):
+    """
+    通过插值边界漂移模拟玩具帕累托份额过程。
+    """
+    rng = np.random.default_rng(seed)
+    n_steps = int(T / dt)
+    t_grid = np.linspace(0, T, n_steps + 1)
+
+    volatility = ω_1 - ω_2
+    m_0 = boundary_drift(ω_1, ω_2, γ, ρ, σ_y)
+    m_1 = -boundary_drift(ω_2, ω_1, γ, ρ, σ_y)
+
+    θ = np.zeros((n_paths, n_steps + 1))
+    dW = rng.normal(0.0, np.sqrt(dt), size=(n_paths, n_steps))
+
+    for t in range(n_steps):
+        υ = 1.0 / (1.0 + np.exp(-θ[:, t]))
+        drift = m_0 * (1 - υ) + m_1 * υ
+        θ[:, t + 1] = θ[:, t] + drift * dt + volatility * dW[:, t]
+
+    υ_paths = 1.0 / (1.0 + np.exp(-θ))
+    return t_grid, υ_paths
+
+
+ω_1 = 0.25
+ω_2 = 0.0
+γ = 5.0
+ρ = 0.67
+σ_y = 0.02
+
+t_grid, υ_paths = simulate_pareto_share_toy(
+    ω_1, ω_2, γ, ρ, σ_y, T=500, dt=0.05, n_paths=50, seed=42
+)
+
+fig, axes = plt.subplots(1, 2, figsize=(14, 5))
+
+ax = axes[0]
+for i in range(20):
+    ax.plot(t_grid, υ_paths[i], color="C0", alpha=0.25, lw=1)
+ax.axhline(0.5, color="gray", linestyle=":", lw=1)
+ax.set_title("样本路径", fontsize=12)
+ax.set_xlabel("时间")
+ax.set_ylabel(r"帕累托份额 $\upsilon_t$")
+ax.set_ylim(0, 1)
+
+ax = axes[1]
+_, υ_long = simulate_pareto_share_toy(
+    ω_1, ω_2, γ, ρ, σ_y, T=2000, dt=0.05, n_paths=5, seed=123
+)
+υ_stationary = υ_long[:, υ_long.shape[1] // 2:].ravel()
+ax.hist(υ_stationary, bins=80, density=True, color="steelblue",
+        edgecolor="white", alpha=0.7)
+ax.set_title("近似平稳密度", fontsize=12)
+ax.set_xlabel(r"帕累托份额 $\upsilon$")
+ax.set_ylabel("密度")
+ax.set_xlim(0, 1)
+
+plt.tight_layout()
+plt.show()
+```
+
+左面板显示了在共存区域内的参数下帕累托份额 $\upsilon_t$ 的 20 条样本路径($\omega^1 = 0.25$，$\omega^2 = 0$，$\gamma = 5$，IES $\approx 1.49$)。
+
+与 {numref}`fig-crra-pareto-paths` 中的可分情形不同，这些路径不会漂向零——它们反复访问广泛的取值范围，在两个排斥边界之间来回弹跳。
+
+右面板通过汇集较长模拟的后半部分来近似平稳密度。
+
+内部模态与两个主体都不被驱向消亡相一致。
+
+然而，这个玩具插值仅仅说明了常返逻辑；它并不重现 {cite:t}`Borovicka2020` 图 4 中定量的平稳消费份额密度，后者需要求解完整的内部均衡 ODE。
+
+## 总结
+
+递归偏好削弱了经典的市场选择结果。
+
+投资组合收益渠道仍然奖励更乐观的信念。
+
+波动率渠道仍然惩罚激进的头寸。
+
+但当 IES $> 1$ 时，储蓄渠道可以足够强以使具有扭曲信念的主体存活。
+
+这就是为什么递归偏好经济体可以支持在信念和投资组合头寸方面具有持续异质性的平稳长期财富分布。


### PR DESCRIPTION
First gap-fill batch of the 37 lectures the intermediate zh-cn edition is missing (full inventory in QuantEcon/project-translation#14 session notes). Seeded with **claude-opus-4-8** via `translate init -f` on action-translation v0.20.0, as the calibration batch before committing to the remaining 32 — review quality here decides whether Opus stays the seed model and whether batch size 5 is right.

| Lecture | Section | Source lines |
| --- | --- | --- |
| `blackwell_kihlstrom` | 统计与信息论 | 1,363 |
| `information_market_equilibrium` | 统计与信息论 | 1,574 |
| `merging_of_opinions` | 统计与信息论 | 1,309 |
| `survival_recursive_preferences` | 统计与信息论 | 1,248 |
| `chow_business_cycles` | 动态系统导论 | 1,652 |

**What's in the diff beyond the five lectures:**

- `_toc.yml`: five entries inserted at the positions mirroring the source TOC order.
- `quant-econ.bib`: synced from source — the five lectures cite 46 keys the old bib lacked (engine gap: QuantEcon/action-translation#117, resync/init don't sync the shared bib). Verified the 15 entries this drops are cited nowhere in this repo.
- `.translate/state/` entries + `.translate/config.yml` (this repo had state files but no config — init bootstraps it), so sync discovery sees these files from day one.
- Font paths post-fixed from the engine's hard-coded `_fonts/` to this repo's `fonts/` convention (engine gap noted in QuantEcon/action-translation#131 thread territory; the font file already exists at `lectures/fonts/`).

Structural checks pass: code-cell and fence counts identical to source on all five, heading maps present, no `text.usetex` (per the zh-editions convention), TOC parses. No environment changes needed — all five use only numpy/scipy/matplotlib.

**This is a draft for native review, not a finished edition** (fr/fa precedent) — the seed guidance treats machine seeds as review drafts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)