### PR TITLE
Bootstrap .translate metadata for the 11 files the resync wave never touched

### DIFF
--- a/.translate/config.yml
+++ b/.translate/config.yml
@@ -1,0 +1,4 @@
+source-language: en
+target-language: zh-cn
+docs-folder: lectures
+tool-version: 0.20.0

--- a/.translate/state/cass_fiscal_2.md.yml
+++ b/.translate/state/cass_fiscal_2.md.yml
@@ -1,0 +1,6 @@
+source-sha: 78030a3a27f6527046675bcd8a8d27995ca25af6
+synced-at: "2025-09-12"
+model: unknown
+mode: RESYNC
+section-count: 2
+tool-version: 0.20.0

--- a/.translate/state/cass_koopmans_2.md.yml
+++ b/.translate/state/cass_koopmans_2.md.yml
@@ -1,0 +1,6 @@
+source-sha: a73ba0f7db0a6783ab5b9cca269a9f95f88106cb
+synced-at: "2025-09-06"
+model: unknown
+mode: RESYNC
+section-count: 8
+tool-version: 0.20.0

--- a/.translate/state/cross_product_trick.md.yml
+++ b/.translate/state/cross_product_trick.md.yml
@@ -1,0 +1,6 @@
+source-sha: fb931c2909a59aa029986a5e6a6083811b5a3aed
+synced-at: "2025-10-15"
+model: unknown
+mode: RESYNC
+section-count: 4
+tool-version: 0.20.0

--- a/.translate/state/divergence_measures.md.yml
+++ b/.translate/state/divergence_measures.md.yml
@@ -1,0 +1,6 @@
+source-sha: 18666c046942325003724125fae0cae91d8be7e7
+synced-at: "2025-09-12"
+model: unknown
+mode: RESYNC
+section-count: 9
+tool-version: 0.20.0

--- a/.translate/state/hoist_failure.md.yml
+++ b/.translate/state/hoist_failure.md.yml
@@ -1,0 +1,6 @@
+source-sha: dd9fd019951cc6936c943bd165686c793b348057
+synced-at: "2025-08-18"
+model: unknown
+mode: RESYNC
+section-count: 15
+tool-version: 0.20.0

--- a/.translate/state/intro.md.yml
+++ b/.translate/state/intro.md.yml
@@ -1,0 +1,6 @@
+source-sha: 1064010d30e47b8b8597a496d5d4743a8c6fa9d0
+synced-at: "2025-03-17"
+model: unknown
+mode: RESYNC
+section-count: 0
+tool-version: 0.20.0

--- a/.translate/state/markov_asset.md.yml
+++ b/.translate/state/markov_asset.md.yml
@@ -1,0 +1,6 @@
+source-sha: a1cd90c5ef6d6f05277318f47fe21eda60fa5e6b
+synced-at: "2025-06-17"
+model: unknown
+mode: RESYNC
+section-count: 5
+tool-version: 0.20.0

--- a/.translate/state/perm_income.md.yml
+++ b/.translate/state/perm_income.md.yml
@@ -1,0 +1,6 @@
+source-sha: a73ba0f7db0a6783ab5b9cca269a9f95f88106cb
+synced-at: "2025-06-17"
+model: unknown
+mode: RESYNC
+section-count: 6
+tool-version: 0.20.0

--- a/.translate/state/re_with_feedback.md.yml
+++ b/.translate/state/re_with_feedback.md.yml
@@ -1,0 +1,6 @@
+source-sha: a1cd90c5ef6d6f05277318f47fe21eda60fa5e6b
+synced-at: "2025-03-19"
+model: unknown
+mode: RESYNC
+section-count: 9
+tool-version: 0.20.0

--- a/.translate/state/uncertainty_traps.md.yml
+++ b/.translate/state/uncertainty_traps.md.yml
@@ -1,0 +1,6 @@
+source-sha: a1cd90c5ef6d6f05277318f47fe21eda60fa5e6b
+synced-at: "2025-06-17"
+model: unknown
+mode: RESYNC
+section-count: 5
+tool-version: 0.20.0

--- a/.translate/state/zreferences.md.yml
+++ b/.translate/state/zreferences.md.yml
@@ -1,0 +1,6 @@
+source-sha: 8b0cb0d5c40b4270a03e1450ca79b0b4607a8bf3
+synced-at: "2025-03-16"
+model: unknown
+mode: RESYNC
+section-count: 0
+tool-version: 0.20.0

--- a/lectures/cass_fiscal_2.md
+++ b/lectures/cass_fiscal_2.md
@@ -9,6 +9,16 @@ kernelspec:
   display_name: Python 3 (ipykernel)
   language: python
   name: python3
+translation:
+  title: 带扭曲性税收的双国模型
+  headings:
+    Overview: 概述
+    A Two-Country Cass-Koopmans Model: 两国Cass-Koopmans模型
+    A Two-Country Cass-Koopmans Model::Capital Mobility and Taxation: 资本流动性和税收
+    A Two-Country Cass-Koopmans Model::Initial condition and steady state: 初始条件和稳态
+    A Two-Country Cass-Koopmans Model::Equilibrium steady state values: 均衡稳态值
+    'A Two-Country Cass-Koopmans Model::Equilibrium steady state values::Experiment 1: A foreseen increase in $g$ from 0.2 to 0.4 at t=10': 实验1：在t=10时预见到g从0.2增加到0.4
+    'A Two-Country Cass-Koopmans Model::Equilibrium steady state values::Experiment 2: A foreseen increase in $g$ from 0.2 to 0.4 at t=10': 实验2：在t=10时$g$从0.2可预见地增加到0.4
 ---
 
 # 带扭曲性税收的双国模型

--- a/lectures/cass_koopmans_2.md
+++ b/lectures/cass_koopmans_2.md
@@ -7,6 +7,26 @@ kernelspec:
   display_name: Python 3
   language: python
   name: python3
+translation:
+  title: Cass-Koopmans竞争均衡
+  headings:
+    Overview: 概述
+    Review of Cass-Koopmans Model: Cass-Koopmans模型回顾
+    Review of Cass-Koopmans Model::Planning Problem: 规划问题
+    Competitive Equilibrium: 竞争均衡
+    Market Structure: 市场结构
+    Market Structure::Prices: 价格
+    Firm Problem: 企业问题
+    Firm Problem::Zero Profit Conditions: 零利润条件
+    Household Problem: 家庭问题
+    Household Problem::Definitions: 定义
+    Computing a Competitive Equilibrium: 计算竞争均衡
+    Computing a Competitive Equilibrium::Guess for Price System: 价格体系的猜测
+    Computing a Competitive Equilibrium::Verification Procedure: 验证程序
+    Computing a Competitive Equilibrium::Household's Lagrangian: 家庭的拉格朗日函数
+    Computing a Competitive Equilibrium::Representative Firm's Problem: 代表性企业的问题
+    Computing a Competitive Equilibrium::Representative Firm's Problem::Varying Curvature: 改变曲率
+    Yield Curves and Hicks-Arrow Prices: 收益率曲线和Hicks-Arrow价格
 ---
 
 (cass_koopmans_2)=

--- a/lectures/cross_product_trick.md
+++ b/lectures/cross_product_trick.md
@@ -9,6 +9,14 @@ kernelspec:
   display_name: Python 3
   language: python
   name: python3
+translation:
+  title: 消除交叉项
+  headings:
+    Overview: 概述
+    Undiscounted Dynamic Programming Problem: 无折现动态规划问题
+    Kalman Filter: 卡尔曼滤波
+    Kalman Filter::Algorithm: 算法
+    Duality table: 对偶表
 ---
 
 # 消除交叉项

--- a/lectures/divergence_measures.md
+++ b/lectures/divergence_measures.md
@@ -9,6 +9,18 @@ kernelspec:
   display_name: Python 3 (ipykernel)
   language: python
   name: python3
+translation:
+  title: 统计散度度量
+  headings:
+    Overview: 概述
+    Primer on entropy, cross-entropy, KL divergence: 熵、交叉熵、KL散度入门
+    'Two Beta distributions: running example': 两个Beta分布：运行示例
+    Kullback–Leibler divergence: Kullback–Leibler散度
+    Jensen-Shannon divergence: Jensen-Shannon散度
+    Chernoff entropy: Chernoff 熵
+    Comparing divergence measures: 比较散度度量
+    KL divergence and maximum-likelihood estimation: KL散度和最大似然估计
+    Related lectures: 相关讲座
 ---
 
 (divergence_measures)=

--- a/lectures/hoist_failure.md
+++ b/lectures/hoist_failure.md
@@ -9,6 +9,23 @@ kernelspec:
   display_name: Python 3
   language: python
   name: python3
+translation:
+  title: 故障树不确定性
+  headings:
+    Overview: 概述
+    Log normal distribution: 对数正态分布
+    The Convolution Property: 卷积性质
+    Approximating Distributions: 近似分布
+    create sums of two and three log normal random variates ssum2 = s1 + s2 and ssum3 = s1 + s2 + s3: 创建两个和三个对数正态随机变量的和 ssum2 = s1 + s2 和 ssum3 = s1 + s2 + s3
+    Cell to check -- note what happens when don't normalize!: 检查单元格 -- 注意当不进行归一化时会发生什么！
+    things match up without adjustment. Compare with above: 无需调整即可匹配。与上面进行比较
+    compute number of points to evaluate the probability mass function: 计算评估概率质量函数的点数
+    Convolving Probability Mass Functions: 概率质量函数的卷积
+    Let's compute the mean of the discretized pdf: 让我们计算离散化pdf的均值
+    Failure Tree Analysis: 故障树分析
+    Application: 应用
+    Failure Rates Unknown: 未知的故障率
+    Waste Hoist Failure Rate: 废物提升机失效率
 ---
 
 

--- a/lectures/intro.md
+++ b/lectures/intro.md
@@ -7,6 +7,8 @@ kernelspec:
   display_name: Python 3
   language: python
   name: python3
+translation:
+  title: Python中级定量经济学
 ---
 
 # Python中级定量经济学

--- a/lectures/markov_asset.md
+++ b/lectures/markov_asset.md
@@ -7,6 +7,31 @@ kernelspec:
   display_name: Python 3
   language: python
   name: python3
+translation:
+  title: 资产定价：有限状态模型
+  headings:
+    Overview: 概述
+    Pricing Models: 定价模型
+    Pricing Models::Risk-Neutral Pricing: 风险中性定价
+    Pricing Models::Pricing with Random Discount Factor: 随机贴现因子定价
+    Pricing Models::Asset Pricing and Covariances: 资产定价与协方差
+    Pricing Models::The Price-Dividend Ratio: 价格-股息比率
+    Prices in the Risk-Neutral Case: 风险中性情况下的价格
+    'Prices in the Risk-Neutral Case::Example 1: Constant Dividends': 示例1：常数股息
+    'Prices in the Risk-Neutral Case::Example 2: Dividends with Deterministic Growth Paths': 示例2：具有确定性增长路径的股息
+    'Prices in the Risk-Neutral Case::Example 3: Markov Growth, Risk-Neutral Pricing': 例3：马尔可夫增长，风险中性定价
+    'Prices in the Risk-Neutral Case::Example 3: Markov Growth, Risk-Neutral Pricing::Pricing Formula': 定价公式
+    Prices in the Risk-Neutral Case::Code: 代码
+    Risk Aversion and Asset Prices: 风险规避与资产价格
+    Risk Aversion and Asset Prices::Pricing a Lucas Tree: 卢卡斯树模型定价
+    Risk Aversion and Asset Prices::Pricing a Lucas Tree::Special Cases: 特殊情况
+    Risk Aversion and Asset Prices::A Risk-Free Consol: 无风险永续债券
+    Risk Aversion and Asset Prices::Pricing an Option to Purchase the Consol: 定价购买永续债券的期权
+    Risk Aversion and Asset Prices::Pricing an Option to Purchase the Consol::An Infinite Horizon Call Option: 无限期限看涨期权
+    Risk Aversion and Asset Prices::Risk-Free Rates: 无风险利率
+    Risk Aversion and Asset Prices::Risk-Free Rates::The One-period Risk-free Interest Rate: 一期无风险利率
+    Risk Aversion and Asset Prices::Risk-Free Rates::Other Terms: 其他期限
+    Exercises: 练习
 ---
 
 (mass)=

--- a/lectures/perm_income.md
+++ b/lectures/perm_income.md
@@ -7,6 +7,30 @@ kernelspec:
   display_name: Python 3
   language: python
   name: python3
+translation:
+  title: 永久收入模型
+  headings:
+    Overview: 概述
+    The Savings Problem: 储蓄问题
+    The Savings Problem::Preliminaries: 预备知识
+    The Savings Problem::The Decision Problem: 决策问题
+    The Savings Problem::Assumptions: 假设
+    The Savings Problem::First-Order Conditions: 一阶条件
+    The Savings Problem::The Optimal Decision Rule: 最优决策规则
+    The Savings Problem::The Optimal Decision Rule::Responding to the State: 对状态的响应
+    The Savings Problem::The Optimal Decision Rule::A State-Space Representation: 状态空间表示
+    The Savings Problem::The Optimal Decision Rule::A Simple Example with IID Income: 一个简单的独立同分布收入示例
+    Alternative Representations: 替代表示方法
+    Alternative Representations::Hall's Representation: 霍尔的表示方法
+    Alternative Representations::Cointegration: 协整
+    Alternative Representations::Cross-Sectional Implications: 横截面含义
+    Alternative Representations::Impulse Response Functions: 脉冲响应函数
+    Alternative Representations::Moving Average Representation: 移动平均表示
+    Two Classic Examples: 两个经典例子
+    Two Classic Examples::Example 1: 示例1
+    Two Classic Examples::Example 2: 示例2
+    Further Reading: 延伸阅读
+    'Appendix: The Euler Equation': 附录：欧拉方程
 ---
 
 (perm_income)=

--- a/lectures/re_with_feedback.md
+++ b/lectures/re_with_feedback.md
@@ -7,6 +7,23 @@ kernelspec:
   display_name: Python 3
   language: python
   name: python3
+translation:
+  title: 线性理性预期模型中的稳定性
+  headings:
+    Overview: 概述
+    Linear Difference Equations: 线性差分方程
+    Linear Difference Equations::First Order: 一阶方程
+    Linear Difference Equations::Second Order: 二阶
+    'Illustration: Cagan''s Model': 示例：凯根模型
+    Some Python Code: Python代码示例
+    Alternative Code: 替代代码
+    Alternative Code::Special Case: 特殊情况
+    Another Perspective: 另一个视角
+    Another Perspective::Refining the Formula: 完善公式
+    Another Perspective::Remarks about Feedback: 关于反馈的说明
+    Log money Supply Feeds Back on Log Price Level: 对数货币供应对对数价格水平的反馈
+    Big $P$, Little $p$ Interpretation: 大 $P$，小 $p$ 解释
+    Fun with SymPy: 玩转 SymPy
 ---
 
 (re_with_feedback)=

--- a/lectures/uncertainty_traps.md
+++ b/lectures/uncertainty_traps.md
@@ -7,6 +7,18 @@ kernelspec:
   display_name: Python 3
   language: python
   name: python3
+translation:
+  title: 不确定性陷阱
+  headings:
+    Overview: 概述
+    The Model: 模型
+    The Model::Fundamentals: 基本原理
+    The Model::Output: 产出
+    The Model::Information and Beliefs: 信息和信念
+    The Model::Participation: 参与
+    Implementation: 实现
+    Results: 结果
+    Exercises: 练习
 ---
 
 (uncertainty_traps)=

--- a/lectures/zreferences.md
+++ b/lectures/zreferences.md
@@ -7,6 +7,8 @@ kernelspec:
   display_name: Python 3
   language: python
   name: python3
+translation:
+  title: 参考文献
 ---
 
 (references)=


### PR DESCRIPTION
Final piece of the QuantEcon/project-translation#14 step-1 audit: files with no `.translate/state` were invisible to sync discovery (the wave's known blind spot). This adds the missing metadata so discovery sees the whole corpus.

**Contents** (23 files):

- **11 new `.translate/state/` entries** — `cass_fiscal_2`, `cass_koopmans_2`, `cross_product_trick`, `divergence_measures`, `hoist_failure`, `intro`, `markov_asset`, `perm_income`, `re_with_feedback`, `uncertainty_traps`, `zreferences`
- **11 heading-map injections** (`translate headingmap`, position-based, frontmatter-only — no body changes) for the same files, which as hand-translated files never had maps; without them section-level sync cannot match sections
- **`.translate/config.yml`** — the repo had state files but no config

**Safety on the `--force` write**: six of these files had source commits newer than their translations, so `--write-state` correctly refused at first. Each was triaged by `translate forward` before forcing: `cass_fiscal_2` and `intro` came back **IDENTICAL** (the upstream changes are already reflected / netted out), and the other four **I18N_ONLY** (the target's deliberate CJK font-config and figsize conventions). No real drift is masked by recording current source HEAD as their baseline. The 73 existing state files are untouched.

**Verification**: `translate status` on this branch reads **84 aligned + 37 source-only, zero outdated, zero missing heading-maps** — the target corpus is fully visible and verified convergent. With this merged, the only remaining #14 items are the sync automation (QuantEcon/lecture-python.myst#979 + org-secret check) and the e2e verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)