### PR TITLE
Remove three duplicate bibliography entries so the .bib parses at all

### DIFF
--- a/lectures/_static/quant-econ.bib
+++ b/lectures/_static/quant-econ.bib
@@ -4104,43 +4104,6 @@
   pages   = {1249--1273},
   year    = {1987}
 }
-
-@article{GilboaSchmeidler:1989,
- 	author = {Gilboa, Itzhak and Schmeidler, David},
- 	date-added = {2020-08-10 09:11:02 -0500},
- 	date-modified = {2020-08-10 09:11:02 -0500},
- 	journal = {Journal of Mathematical Economics},
- 	keywords = {climate,modeling},
- 	mendeley-groups = {nsfbib},
- 	month = {apr},
- 	number = {2},
- 	pages = {141--153},
- 	title = {{Maxmin Expected Utility with Non-Unique Prior}},
- 	volume = {18},
- 	year = {1989}
-}
-
-@article{Whittle_1981,
-  author = {Peter Whittle},
-  year = {1981},
-  title = {Risk-Sensitive Linear/Quadratic/Gaussian Control},
-  journal = {Advances in Applied Probability},
-  volume = {13},
-  number = {4},
-  pages = {764-777}
-}
-
-@book{Whittle_1990,
-  author = {Peter Whittle},
-  title = {Risk-Sensitive Optimal Control},
-  year = {1990},
-  publisher = {Wiley},
-  address = {New York}
-}
-
-
-
-
 % ---------------------------------------------------------------------------
 % Entries synced from QuantEcon/lecture-python.myst lectures/_static/quant-econ.bib
 % on 2026-07-24. The sync action does not carry shared assets across


### PR DESCRIPTION
`pybtex` refuses to parse a bibliography containing a repeated key, and this file has carried **three** of them. `GilboaSchmeidler:1989`, `Whittle_1981` and `Whittle_1990` each appear twice — once indented in the main body, once unindented near the end — and the two copies of each are byte-identical apart from leading whitespace.

## The effect is total, not local

```
BibliographyDataError: repeated bibliography entry: GilboaSchmeidler:1989
```

`parse_file` raises, no bibliography is built, and **every** `{cite}` in the edition fails to resolve. That is what the `could not find bibtex key` warnings on [#202](https://github.com/QuantEcon/lecture-python.zh-cn/pull/202) actually are: the keys are present in the file, and nothing ever parsed it.

This also means the 70 entries backfilled in [#203](https://github.com/QuantEcon/lecture-python.zh-cn/pull/203) were correct but could never have taken effect. #202 would have stayed red no matter how many entries were added.

## It predates #203

The same three duplicates and the same parse error are present at `693aa63`, before that PR. Confirmed by parsing that blob directly.

Why it went unnoticed is worth recording: a duplicate key is invisible to the obvious checks. A `grep -c '^@'` count is unaffected, braces stay balanced, and a `^@`-anchored duplicate scan misses it entirely because one copy of each pair is **indented**. It only surfaces when something actually parses the file with a real BibTeX parser.

## Verification

| | |
|---|---|
| `pybtex` parse | 480 entries, no error |
| Keys #202's build reported missing | 61 |
| Still unresolved after this change | **0** |
| The three formerly-duplicated keys | all resolve |

Removes the later copy of each; the earlier copy in the main body is kept.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
