### PR TITLE
Fix tofu in Chinese figure labels, and give font.family a fallback

### DIFF
--- a/lectures/affine_risk_prices.md
+++ b/lectures/affine_risk_prices.md
@@ -568,8 +568,7 @@ mystnb:
 import matplotlib as mpl  # i18n
 FONTPATH = "fonts/SourceHanSerifSC-SemiBold.otf"  # i18n
 mpl.font_manager.fontManager.addfont(FONTPATH)  # i18n
-mpl.rcParams['font.family'] = ['Source Han Serif SC']  # i18n
-
+mpl.rcParams['font.family'] = ['Source Han Serif SC', 'DejaVu Sans']  # i18n
 n_max_1f = 60
 maturities_1f = np.arange(1, n_max_1f + 1)
 

--- a/lectures/career.md
+++ b/lectures/career.md
@@ -64,7 +64,7 @@ import matplotlib.pyplot as plt
 import matplotlib as mpl
 FONTPATH = "fonts/SourceHanSerifSC-SemiBold.otf"
 mpl.font_manager.fontManager.addfont(FONTPATH)
-plt.rcParams['font.family'] = ['Source Han Serif SC']
+plt.rcParams['font.family'] = ['Source Han Serif SC', 'DejaVu Sans']
 
 from matplotlib import cm
 from mpl_toolkits.mplot3d.axes3d import Axes3D

--- a/lectures/divergence_measures.md
+++ b/lectures/divergence_measures.md
@@ -63,6 +63,10 @@ translation:
 
 ```{code-cell} ipython3
 import matplotlib.pyplot as plt
+import matplotlib as mpl
+FONTPATH = "fonts/SourceHanSerifSC-SemiBold.otf"
+mpl.font_manager.fontManager.addfont(FONTPATH)
+plt.rcParams['font.family'] = ['Source Han Serif SC']
 import numpy as np
 from numba import vectorize, jit
 from math import gamma

--- a/lectures/divergence_measures.md
+++ b/lectures/divergence_measures.md
@@ -66,7 +66,7 @@ import matplotlib.pyplot as plt
 import matplotlib as mpl
 FONTPATH = "fonts/SourceHanSerifSC-SemiBold.otf"
 mpl.font_manager.fontManager.addfont(FONTPATH)
-plt.rcParams['font.family'] = ['Source Han Serif SC']
+plt.rcParams['font.family'] = ['Source Han Serif SC', 'DejaVu Sans']
 import numpy as np
 from numba import vectorize, jit
 from math import gamma

--- a/lectures/jv.md
+++ b/lectures/jv.md
@@ -56,7 +56,7 @@ import matplotlib.pyplot as plt
 import matplotlib as mpl
 FONTPATH = "fonts/SourceHanSerifSC-SemiBold.otf"
 mpl.font_manager.fontManager.addfont(FONTPATH)
-plt.rcParams['font.family'] = ['Source Han Serif SC']
+plt.rcParams['font.family'] = ['Source Han Serif SC', 'DejaVu Sans']
 import scipy.stats as stats
 import jax
 import jax.numpy as jnp

--- a/lectures/jv.md
+++ b/lectures/jv.md
@@ -53,6 +53,10 @@ translation:
 from typing import NamedTuple
 
 import matplotlib.pyplot as plt
+import matplotlib as mpl
+FONTPATH = "fonts/SourceHanSerifSC-SemiBold.otf"
+mpl.font_manager.fontManager.addfont(FONTPATH)
+plt.rcParams['font.family'] = ['Source Han Serif SC']
 import scipy.stats as stats
 import jax
 import jax.numpy as jnp

--- a/lectures/kesten_processes.md
+++ b/lectures/kesten_processes.md
@@ -73,6 +73,10 @@ translation:
 
 ```{code-cell} ipython3
 import matplotlib.pyplot as plt
+import matplotlib as mpl
+FONTPATH = "fonts/SourceHanSerifSC-SemiBold.otf"
+mpl.font_manager.fontManager.addfont(FONTPATH)
+plt.rcParams['font.family'] = ['Source Han Serif SC']
 import numpy as np
 import quantecon as qe
 import yfinance as yf

--- a/lectures/kesten_processes.md
+++ b/lectures/kesten_processes.md
@@ -76,7 +76,7 @@ import matplotlib.pyplot as plt
 import matplotlib as mpl
 FONTPATH = "fonts/SourceHanSerifSC-SemiBold.otf"
 mpl.font_manager.fontManager.addfont(FONTPATH)
-plt.rcParams['font.family'] = ['Source Han Serif SC']
+plt.rcParams['font.family'] = ['Source Han Serif SC', 'DejaVu Sans']
 import numpy as np
 import quantecon as qe
 import yfinance as yf


### PR DESCRIPTION
Restores the font block in `divergence_measures.md`, `kesten_processes.md` and `jv.md`, and adds the fallback to `career.md` and `affine_risk_prices.md`, which already carried the block and were silently losing `ϵ` and `r₁` to it.

`divergence_measures` is live on the published site today; the other two are queued behind the next publish. Provenance note: `jv` and `kesten_processes` lost their block to resyncs (`965ad3e`, `da7b176`), while `divergence_measures` never had one — its Chinese labels were hand-added after the original blanket pass.

Chinese figure labels in these lectures render as **tofu** — blank rectangles — because the notebook never registers a CJK font. matplotlib falls back to DejaVu Sans, which has no CJK coverage, emits a `UserWarning`, substitutes boxes, and writes a perfectly valid PNG. Nothing fails.

## Two changes, and the second is the interesting one

**1. Register the font** where it was missing, following this edition's existing convention and path.

**2. Give `font.family` a fallback.** This is a deliberate deviation from the single-entry form used elsewhere in the estate, and it is a defect fix rather than a style choice.

Setting `font.family` to a single entry **removes matplotlib's per-glyph fallback**. Source Han Serif SC follows Adobe-GB1, which omits subscript digits (U+2080–U+2083), the vertical ellipsis (U+22EE) and the symbol Greek forms (U+03F5 ϵ, U+03D5 ϕ) — characters these lectures genuinely use in labels. So the naive fix would have swapped one set of blank boxes for another.

Measured on matplotlib 3.11.1 against this repo's own font file, rendering a label containing 密钥拆分树, `key₀`, `⋮`, `ϵ` and `ϕ`:

| `font.family` | missing-glyph warnings |
|---|---|
| `['Source Han Serif SC']` | **4** |
| `['Source Han Serif SC', 'DejaVu Sans']` | **0** |

CJK still comes from Source Han Serif; everything outside Adobe-GB1 now falls back instead of vanishing.

## Why this was invisible

The missing-glyph warning is raised inside the Jupyter kernel subprocess. Sphinx's `-W` only escalates Sphinx-logger warnings, so CI never sees it — myst-nb renders it into the **published page** as stderr output instead. No CI log in the estate has ever contained `findfont` or `Glyph … missing`.

A detector now exists (`bin/check-tofu` in `project-translation`), validated against the live sites. It found pages that source-level analysis missed, because it reads what was actually rendered.

## Background

Full history, the argument against reverting to `text.usetex`, and the recommendation to replace per-lecture injection with a build-level mechanism: [project-translation reports/2026-07-24-cjk-font-rendering-review.md](https://github.com/QuantEcon/project-translation/blob/main/reports/2026-07-24-cjk-font-rendering-review.md). Engine side: [action-translation#182](https://github.com/QuantEcon/action-translation/issues/182) (resync strips these blocks; the guardrail is prompt prose).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
