### PR TITLE
🌐 [translation-sync] [ifp_advanced] Align K with the (c, a) convention used across the EGM lectures

### DIFF
--- a/.translate/state/ifp_advanced.md.yml
+++ b/.translate/state/ifp_advanced.md.yml
@@ -1,5 +1,5 @@
-source-sha: a4fbd8653600ac99163bfd5d4f7d98c1e613042e
-synced-at: "2026-07-26"
+source-sha: 60af4806201dc1bc99275122aea5b7dc7bd02a52
+synced-at: "2026-07-29"
 model: claude-sonnet-5
 mode: UPDATE
 section-count: 7

--- a/lectures/ifp_advanced.md
+++ b/lectures/ifp_advanced.md
@@ -366,8 +366,8 @@ def Y(z, η, a_y, b_y):
 
 ```{code-cell} ipython3
 def K(
-        a_in: jnp.array,   # a_in[i, z] 是资产网格
         c_in: jnp.array,   # c_in[i, z] = a_in[i, z] 处的消费
+        a_in: jnp.array,   # a_in[i, z] 是资产网格
         ifp: IFP
     ):
     """
@@ -408,7 +408,7 @@ def K(
     c_out = c_out.at[0, :].set(0)
     a_out = a_out.at[0, :].set(0)
 
-    return a_out, c_out
+    return c_out, a_out
 ```
 
 下一个函数使用 JAX 通过时间迭代求解最优消费政策的近似：
@@ -464,15 +464,15 @@ a_init = σ_init.copy()
 让我们用 JAX 生成一个近似解：
 
 ```{code-cell} ipython3
-a_star, σ_star = solve_model(ifp, a_init, σ_init)
+σ_star, a_star = solve_model(ifp, σ_init, a_init)
 ```
 
 让我们再用计时器试一次。
 
 ```{code-cell} python3
 with qe.Timer(precision=8):
-    a_star, σ_star = solve_model(ifp, a_init, σ_init)
-    a_star.block_until_ready()
+    σ_star, a_star = solve_model(ifp, σ_init, a_init)
+    σ_star.block_until_ready()
 ```
 
 ## 模拟
@@ -614,7 +614,7 @@ s_grid = ifp.s_grid
 n_z = len(ifp.P)
 a_init = s_grid[:, None] * jnp.ones(n_z)
 c_init = a_init
-a_vec, c_vec = solve_model(ifp, a_init, c_init)
+c_vec, a_vec = solve_model(ifp, c_init, a_init)
 assets = compute_asset_stationary(c_vec, a_vec, ifp, num_households=200_000)
 
 # 为图形计算基尼系数
@@ -700,8 +700,8 @@ for a_r in a_r_vals:
     n_z_temp = len(ifp_temp.P)
     a_init_temp = s_grid_temp[:, None] * jnp.ones(n_z_temp)
     c_init_temp = a_init_temp
-    a_vec_temp, c_vec_temp = solve_model(
-        ifp_temp, a_init_temp, c_init_temp
+    c_vec_temp, a_vec_temp = solve_model(
+        ifp_temp, c_init_temp, a_init_temp
     )
 
     # 模拟家庭
@@ -772,8 +772,8 @@ for a_y in a_y_vals:
     n_z_temp = len(ifp_temp.P)
     a_init_temp = s_grid_temp[:, None] * jnp.ones(n_z_temp)
     c_init_temp = a_init_temp
-    a_vec_temp, c_vec_temp = solve_model(
-        ifp_temp, a_init_temp, c_init_temp
+    c_vec_temp, a_vec_temp = solve_model(
+        ifp_temp, c_init_temp, a_init_temp
     )
 
     # 模拟家庭


### PR DESCRIPTION
## Automated Translation Sync

This PR contains automated translations from [QuantEcon/lecture-python.myst](https://github.com/QuantEcon/lecture-python.myst).

### Source PR
**[#1016 - [ifp_advanced] Align K with the (c, a) convention used across the EGM lectures](https://github.com/QuantEcon/lecture-python.myst/pull/1016)**

### Files Updated
- ✏️ `lectures/ifp_advanced.md`
- ✏️ `.translate/state/ifp_advanced.md.yml`

### Details
- **Source Language**: en
- **Target Language**: zh-cn
- **Model**: claude-sonnet-5

---
*This PR was created automatically by the [translation action](https://github.com/quantecon/action-translation).*

<!-- translation-sync-metadata
{
  "schemaVersion": 1,
  "sourceRepo": "QuantEcon/lecture-python.myst",
  "sourcePR": 1016,
  "mode": "sync",
  "sourceCommitSha": "60af4806201dc1bc99275122aea5b7dc7bd02a52",
  "targetBaseSha": "bf8200ad65f37607df47c6040eb581a60a14ecbf",
  "sourceLanguage": "en",
  "targetLanguage": "zh-cn",
  "claudeModel": "claude-sonnet-5",
  "files": [
    {
      "path": "lectures/ifp_advanced.md",
      "type": "markdown"
    }
  ]
}
-->