### PR TITLE
Restore Chinese part captions — the published ToC has been English for 17 days

### DIFF
--- a/lectures/_toc.yml
+++ b/lectures/_toc.yml
@@ -1,7 +1,7 @@
 format: jb-book
 root: intro
 parts:
-- caption: Tools and Techniques
+- caption: 基础工具
   numbered: true
   chapters:
   - file: sir_model
@@ -11,7 +11,7 @@ parts:
   - file: svd_intro
   - file: var_dmd
   - file: newton_method
-- caption: Elementary Statistics
+- caption: 基础统计学
   numbered: true 
   chapters:
   - file: prob_matrix
@@ -24,13 +24,13 @@ parts:
   - file: back_prop
   - file: rand_resp
   - file: util_rand_resp
-- caption: Bayes Law
+- caption: 贝叶斯定律
   numbered: true
   chapters:
   - file:  bayes_nonconj
   - file:  ar1_bayes
   - file:  ar1_turningpts
-- caption: Statistics and Information 
+- caption: 统计与信息论
   numbered: true
   chapters:
   - file: divergence_measures
@@ -50,12 +50,12 @@ parts:
   - file: survival_recursive_preferences
   - file: pricing_information
   - file: market_diffusion
-- caption: Linear Programming
+- caption: 线性规划
   numbered: true
   chapters:
   - file: opt_transport
   - file: von_neumann_model
-- caption: Introduction to Dynamics
+- caption: 动态系统导论
   numbered: true
   chapters:
   - file: finite_markov
@@ -71,7 +71,7 @@ parts:
   - file: var_subsets
   - file: organization_capital
   - file: measurement_models
-- caption: Search
+- caption: 搜索
   numbered: true
   chapters:
   - file: mccall_model
@@ -82,13 +82,13 @@ parts:
   - file: career
   - file: jv
   - file: odu
-- caption: Reinforcement Learning
+- caption: 强化学习
   numbered: true
   chapters:
   - file: inventory_q
   - file: rs_inventory_q
   - file: mccall_q
-- caption: Introduction to Optimal Savings
+- caption: 最优储蓄导论
   numbered: true
   chapters:
   - file: os
@@ -97,7 +97,7 @@ parts:
   - file: os_time_iter
   - file: os_egm
   - file: os_egm_jax
-- caption: Household Problems
+- caption: 家庭问题
   numbered: true
   chapters:
   - file: ifp_discrete
@@ -105,7 +105,7 @@ parts:
   - file: ifp_egm
   - file: ifp_egm_transient_shocks
   - file: ifp_advanced
-- caption: LQ Control
+- caption: LQ控制
   numbered: true
   chapters:
   - file: lqcontrol
@@ -121,7 +121,7 @@ parts:
   - file: lq_robust_smoothing
   - file: lq_robust_bewley
   - file: lq_inventories
-- caption: Bounded Rationality in Macroeconomics
+- caption: 宏观经济学中的有限理性
   numbered: true
   chapters:
   - file: bounded_rationality
@@ -130,7 +130,7 @@ parts:
   - file: genetic_classifier
   - file: marimon_mcgrattan_sargent
   - file: prospects_bounded_rationality
-- caption: Phillips Curve Tradeoffs
+- caption: 菲利普斯曲线权衡
   numbered: true
   chapters:
   - file: phillips_two_stories
@@ -144,14 +144,14 @@ parts:
   - file: phillips_priors
   - file: phillips_lost_conquest
   - file: phillips_drifts_volatilities
-- caption: Optimal Growth
+- caption: 最优增长
   numbered: true
   chapters:
   - file: cass_koopmans_1
   - file: cass_koopmans_2
   - file: cass_fiscal
   - file: cass_fiscal_2
-- caption: Multiple Agent Models
+- caption: 多主体模型
   numbered: true
   chapters:
   - file: lake_model
@@ -165,7 +165,7 @@ parts:
   - file: ak2
   - file: ak_aiyagari
   - file: two_computation
-- caption: Asset Pricing and Finance
+- caption: 资产定价与金融
   numbered: true
   chapters:
   - file: markov_asset
@@ -180,7 +180,7 @@ parts:
   - file: ross_recovery
   - file: long_run_risk_operator
   - file: misspecified_recovery
-- caption: Data and Empirics
+- caption: 数据与实证
   numbered: true
   chapters:
   - file: pandas_panel
@@ -189,12 +189,12 @@ parts:
   - file: unemployment_linear
   - file: unemployment_shocks
   - file: sargent_surico
-- caption: Auctions
+- caption: 拍卖
   numbered: true 
   chapters:
   - file: two_auctions
   - file: house_auction
-- caption: Other
+- caption: 其他
   numbered: true
   chapters:
   - file: troubleshooting


### PR DESCRIPTION
The published Chinese site has been serving **19 English section captions and zero Chinese ones** since #202 merged on 2026-07-24 — seventeen days live on the flagship Chinese edition. This restores them.

## What happened

#202 (`84fbaca`) regenerated `lectures/_toc.yml` as a full mirror of the English source, which carried the English captions over the 14 hand-set Chinese ones. The reviewer scored that PR `PASS`, 9/9/9/9, all four diff-checks true, with `recommendationReasons: []` — a prose-quality reviewer does not see a structural de-localisation, which is why nothing flagged it.

## This is not a revert

Upstream restructured the parts in the same change, so the caption set went from 14 to 19. The old `消费、储蓄与资本` part held 16 lectures and was dissolved **four** ways:

| Old member | Now under |
|---|---|
| `cass_koopmans_1/2`, `cass_fiscal`, `cass_fiscal_2` | Optimal Growth |
| the six `os_*` | Introduction to Optimal Savings |
| the five `ifp_*` | Household Problems |
| `ak2` | Multiple Agent Models (existing part) |

Three lectures also moved out of Search into a new Reinforcement Learning part. So 13 captions are restored verbatim from `f8bf219` (#202's parent) and 6 are new. The retired `消费、储蓄与资本` is **not** recycled — no successor part carries its scope, so reusing it would mislabel a section. 14 − 1 + 6 = 19, matching the English caption count exactly.

## The six new captions are attested, not coined

Each is a phrase this edition already uses for the same English string:

| Caption | Attestation |
|---|---|
| `强化学习` | `inventory_q.md:514`, `prospects_bounded_rationality.md:539` |
| `最优储蓄导论` | `os.md:11` and `:28` — the part's **own lead-lecture title** |
| `家庭问题` | `ifp_discrete.md:34` (*"这个储蓄问题通常被称为**收入波动问题**或**家庭问题**"*), plus heading-map pairs at `cass_koopmans_2.md:21` and `ak_aiyagari.md:28`; 29 occurrences across 11 files |
| `宏观经济学中的有限理性` | `prospects_bounded_rationality.md:55`, rendering Sargent (1993) — whose title *is* the English caption |
| `菲利普斯曲线权衡` | `phillips_lost_conquest.md:53`, which already names this very suite |
| `最优增长` | `cass_koopmans_1.md:44`, describing the part's own subject |

`X导论` for *"Introduction to X"* follows this repo's own lost caption `动态系统导论` ← *"Introduction to Dynamics"*. `其他` is kept at position 19 — this repo's form; lecture-intro.zh-cn uses `其它` and the two were deliberately not harmonised here.

## 🟡 One call for @HumphreyYang

**Household Problems → `家庭问题`, or `收入波动问题`?** This was the one genuinely contested choice.

`家庭问题` translates the English caption and is what the part's own lead lecture calls its subject. But all five member lectures are titled `收入波动问题 I–V`, so under `家庭问题` the caption shares no character with any page title beneath it, and bare `家庭问题` has an everyday reading ("family troubles") that prose disambiguates but a navigation label does not.

Both are defensible — `ifp_discrete.md:34` explicitly equates the two names. This is a traceability-versus-clarity judgement rather than a correctness question, so it should be yours. Happy to swap it at position 10 if you prefer the series name.

Also worth a second opinion, though not contested: `Optimal Growth → 最优增长` versus `最优增长模型`. The bare form was chosen because the English caption is bare and the part also covers competitive equilibrium and fiscal policy, but `多主体模型` shows `模型` does appear in this repo's captions.

## Scope and durability

The diff is **19 caption lines and nothing else** — 19 insertions, 19 deletions, zero non-caption changed lines. No YAML quoting is needed (no ASCII colons). The trailing space on the old `"Statistics and Information "` is not carried over.

**This is a bridge repair, not a durable fix.** `_toc.yml` is regenerated as a full source mirror by lecture-adding syncs, so the next one reverts it — the same mechanism that caused this. Nothing enforces caption language today: the engine reads `_toc.yml` only for lecture discovery and no mode emits a translated caption, so review mode's gating `terminology` category never sees a caption regression. Filed for the durable fix. No open sync PR touches `_toc.yml` right now, so the window is clear.

Once merged this needs a publish tag to reach readers; verify after the ~10-minute Pages CDN window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
