### PR TITLE
Rename the ifp part caption to 收入波动问题 (#246 ruling)

### DIFF
--- a/lectures/_toc.yml
+++ b/lectures/_toc.yml
@@ -97,7 +97,7 @@ parts:
   - file: os_time_iter
   - file: os_egm
   - file: os_egm_jax
-- caption: 家庭问题
+- caption: 收入波动问题
   numbered: true
   chapters:
   - file: ifp_discrete


### PR DESCRIPTION
Applies @HumphreyYang's ruling in #246 (2026-08-11): the part caption in `_toc.yml` becomes **收入波动问题**, which names the income-fluctuation-problem chapters (`ifp_*`) accurately. The other half of the ruling is a standing convention rather than a diff: **家庭问题** stays in lecture body text wherever "household's problem" contrasts with "firm's problem".

Prose-only ToC change, so it publishes without a cache run. #246 can close when this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
