### PR TITLE
Translate theil_2's four seed-delivered figure captions

### DIFF
--- a/lectures/theil_2.md
+++ b/lectures/theil_2.md
@@ -140,7 +140,7 @@ x_{t+1} = g(x_t,\, z_t,\, u_t).
 ---
 mystnb:
   figure:
-    caption: CE principle -- policy vs. value
+    caption: CE 原理——策略与价值的对比
     name: fig-ce-policy-value
 ---
 a, b_coeff = 0.9, 1.0
@@ -298,7 +298,7 @@ u_t = h_1\!\left(x_t,\; \hat{h}_2 \cdot y_t\right) = h(x_t, z_t).
 ---
 mystnb:
   figure:
-    caption: Robust policy varies with θ
+    caption: 稳健策略随 θ 变化
     name: fig-robust-policy-theta
 ---
 σ_fixed = 1.0
@@ -574,7 +574,7 @@ print(f"β_tilde = {bt:.5f}, φ_tilde = {φ_rob:.4f}, ν_tilde = {ν_rob:.4f}")
 ---
 mystnb:
   figure:
-    caption: Standard vs robust consumption paths
+    caption: 标准与稳健消费路径的对比
     name: fig-std-vs-robust-paths
 ---
 np.random.seed(0)
@@ -630,7 +630,7 @@ plt.show()
 ---
 mystnb:
   figure:
-    caption: Observational equivalence locus
+    caption: 观测等价轨迹
     name: fig-oe-locus
 ---
 σ_range = np.linspace(-3e-7, 0.0, 200)


### PR DESCRIPTION
Hand-translates the four English `mystnb` figure captions in `theil_2.md` into Chinese. These are the durable residual of the untranslated-caption class tracked in QuantEcon/action-translation#255: they arrived via the 2026-07-22 bulk `init` seed (#196), so no future sync re-delivers this lecture and hand work here cannot be overwritten by an engine fix.

| Line | Was | Now |
|---|---|---|
| 143 | CE principle -- policy vs. value | CE 原理——策略与价值的对比 |
| 301 | Robust policy varies with θ | 稳健策略随 θ 变化 |
| 577 | Standard vs robust consumption paths | 标准与稳健消费路径的对比 |
| 633 | Observational equivalence locus | 观测等价轨迹 |

观测等价轨迹 matches `lq_robust_bewley.md`'s existing rendering of "observational-equivalence locus"; CE is the lecture's own established abbreviation (确定性等价). The sync-delivered lectures carrying the same defect are deliberately **not** touched here — they wait for the engine ruling in QuantEcon/action-translation#255, since an engine-side fix would re-deliver and overwrite them.

Prose-only, so it publishes without a cache run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
