### PR TITLE
Add editors block: HumphreyYang as editor of record

### DIFF
--- a/.translate/config.yml
+++ b/.translate/config.yml
@@ -2,3 +2,6 @@ source-language: en
 target-language: zh-cn
 docs-folder: lectures
 tool-version: 0.20.0
+editors:
+  primary: HumphreyYang
+  secondary: []


### PR DESCRIPTION
Adds the `editors:` block to `.translate/config.yml`, naming **@HumphreyYang** as this edition's editor of record — one of five staged PRs rolling out Stage 2 of the human-review program (tracker: QuantEcon/project-translation#24, assignments from the program's `team/reviewers.yml`).

Two deliberate mechanics, both ruled in the work plan: **block-style YAML with `primary:` first**, because the flow form `editors: {primary: X}` parses to `None` against the live parser and a `secondary:` list written above `primary:` would mis-assign; and **hand-edited rather than bootstrapped**, because `writeConfig` would restamp `tool-version` and muddy the pin-drift picture in QuantEcon/project-translation#4. `secondary` stays empty until the RA cohort is ruled on.

The Action does not read this file, so the change is inert to sync; the consumer is the status-translations collector, and the dashboard's `primary_editor` field should flip on the first nightly collect after merge (`17 3 * * *`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
