### PR TITLE
Fix learning_approximation FONTPATH: _fonts/ → fonts/ (unbreaks the cache build)

### DIFF
--- a/lectures/learning_approximation.md
+++ b/lectures/learning_approximation.md
@@ -101,7 +101,7 @@ import pandas as pd
 import quantecon as qe
 import matplotlib.pyplot as plt
 import matplotlib as mpl  # i18n
-FONTPATH = "_fonts/SourceHanSerifSC-SemiBold.otf"  # i18n
+FONTPATH = "fonts/SourceHanSerifSC-SemiBold.otf"  # i18n
 mpl.font_manager.fontManager.addfont(FONTPATH)  # i18n
 mpl.rcParams['font.family'] = ['Source Han Serif SC']  # i18n
 from scipy.optimize import brentq


### PR DESCRIPTION
One-line fix for the failure that blocked today's publish: the 2026-08-20 `cache.yml` run ([32331172292](https://github.com/QuantEcon/lecture-python.zh-cn/actions/runs/32331172292)) failed on `Build HTML` with

    FileNotFoundError: [Errno 2] No such file or directory: '_fonts/SourceHanSerifSC-SemiBold.otf'

while executing `learning_approximation.md`'s import cell.

## Cause — a known seed gotcha, missed in #261

The engine's `i18n-font-config` localisation rule hard-codes `_fonts/`; this edition keeps the font at `lectures/fonts/`. Every other font-loading lecture here uses `fonts/` — **116 references across 36 lectures, against this single `_fonts/` one**. Repointing the path was the one documented seed-gotcha the [#261](https://github.com/QuantEcon/lecture-python.zh-cn/pull/261) gap-fill missed: its verification checked the font block was *present* but not the *path*.

Why it slipped past CI: #261's PR preview build tolerated the `CellExecutionError` as a mystnb warning and passed, so the defect surfaced only when the strict cache build executed the lecture. (My post-merge note on #261 claiming the build "executed all 17 code cells" was therefore too strong — the run completed, but this cell's failure was warned, not raised. The cache build is the real gate.)

## Verification

- `git grep '_fonts' -- lectures/` after the change: zero occurrences.
- The asset exists at `lectures/fonts/SourceHanSerifSC-SemiBold.otf`.
- The identical block form is what `mobility.md` uses on lecture-intro.zh-cn, whose cache build passed today with the lecture executing.

## Sequencing

On merge, `cache.yml` needs a dispatch (the failed run left no fresh artifact), and once green `publish-2026aug20` can be tagged — intro.zh-cn's tag is already pushed and publishing. Recorded on [zh-cn#210](https://github.com/QuantEcon/lecture-python.zh-cn/issues/210)'s successor trail via the work plan.
