### PR TITLE
CI: add timeout and retry to apt-get install steps

### DIFF
--- a/.github/workflows/cache.yml
+++ b/.github/workflows/cache.yml
@@ -22,22 +22,24 @@ jobs:
       - name: graphviz Support # TODO: required?
         timeout-minutes: 10
         run: |
-          # Retried with a per-attempt timeout: a stalled Ubuntu mirror otherwise
+          # Retried with per-command timeouts (timeout inside sudo, so the kill reaches
+          # apt-get and the dpkg lock is released): a stalled Ubuntu mirror otherwise
           # hangs this step for hours (two 358-minute hangs on 2026-08-18).
           pkgs="graphviz"
           for attempt in 1 2; do
-            timeout 4m sudo bash -c "apt-get -qq update && apt-get install -y $pkgs" && break
+            sudo timeout -k 30s 1m apt-get -qq update && sudo timeout -k 30s 3m apt-get install -y $pkgs && break
             if [ "$attempt" = 2 ]; then echo "apt-get failed after 2 attempts"; exit 1; fi
             echo "apt-get attempt $attempt failed; retrying in 30s"; sleep 30
           done
       - name: Install latex dependencies
         timeout-minutes: 30
         run: |
-          # Retried with a per-attempt timeout: a stalled Ubuntu mirror otherwise
+          # Retried with per-command timeouts (timeout inside sudo, so the kill reaches
+          # apt-get and the dpkg lock is released): a stalled Ubuntu mirror otherwise
           # hangs this step for hours (two 358-minute hangs on 2026-08-18).
           pkgs="texlive-latex-recommended texlive-latex-extra texlive-fonts-recommended texlive-fonts-extra texlive-xetex latexmk xindy dvipng cm-super latex-cjk-all"
           for attempt in 1 2; do
-            timeout 14m sudo bash -c "apt-get -qq update && apt-get install -y $pkgs" && break
+            sudo timeout -k 30s 2m apt-get -qq update && sudo timeout -k 30s 12m apt-get install -y $pkgs && break
             if [ "$attempt" = 2 ]; then echo "apt-get failed after 2 attempts"; exit 1; fi
             echo "apt-get attempt $attempt failed; retrying in 30s"; sleep 30
           done

--- a/.github/workflows/cache.yml
+++ b/.github/workflows/cache.yml
@@ -20,17 +20,25 @@ jobs:
           environment-file: environment.yml
           activate-environment: quantecon
       - name: graphviz Support # TODO: required?
+        timeout-minutes: 10
         run: |
-          sudo apt-get -qq update && sudo apt-get install -y graphviz
+          # Retried with a per-attempt timeout: a stalled Ubuntu mirror otherwise
+          # hangs this step for hours (two 358-minute hangs on 2026-08-18).
+          pkgs="graphviz"
+          for attempt in 1 2; do
+            timeout 4m sudo bash -c "apt-get -qq update && apt-get install -y $pkgs" && break
+            if [ "$attempt" = 2 ]; then echo "apt-get failed after 2 attempts"; exit 1; fi
+            echo "apt-get attempt $attempt failed; retrying in 30s"; sleep 30
+          done
       - name: Install latex dependencies
         timeout-minutes: 30
         run: |
           # Retried with a per-attempt timeout: a stalled Ubuntu mirror otherwise
           # hangs this step for hours (two 358-minute hangs on 2026-08-18).
           pkgs="texlive-latex-recommended texlive-latex-extra texlive-fonts-recommended texlive-fonts-extra texlive-xetex latexmk xindy dvipng cm-super latex-cjk-all"
-          for attempt in 1 2 3; do
-            timeout 9m sudo bash -c "apt-get -qq update && apt-get install -y $pkgs" && break
-            if [ "$attempt" = 3 ]; then echo "apt-get failed after 3 attempts"; exit 1; fi
+          for attempt in 1 2; do
+            timeout 14m sudo bash -c "apt-get -qq update && apt-get install -y $pkgs" && break
+            if [ "$attempt" = 2 ]; then echo "apt-get failed after 2 attempts"; exit 1; fi
             echo "apt-get attempt $attempt failed; retrying in 30s"; sleep 30
           done
       - name: Build HTML

--- a/.github/workflows/cache.yml
+++ b/.github/workflows/cache.yml
@@ -23,19 +23,16 @@ jobs:
         run: |
           sudo apt-get -qq update && sudo apt-get install -y graphviz
       - name: Install latex dependencies
+        timeout-minutes: 30
         run: |
-          sudo apt-get -qq update
-          sudo apt-get install -y     \
-            texlive-latex-recommended \
-            texlive-latex-extra       \
-            texlive-fonts-recommended \
-            texlive-fonts-extra       \
-            texlive-xetex             \
-            latexmk                   \
-            xindy                     \
-            dvipng                    \
-            cm-super                  \
-            latex-cjk-all
+          # Retried with a per-attempt timeout: a stalled Ubuntu mirror otherwise
+          # hangs this step for hours (two 358-minute hangs on 2026-08-18).
+          pkgs="texlive-latex-recommended texlive-latex-extra texlive-fonts-recommended texlive-fonts-extra texlive-xetex latexmk xindy dvipng cm-super latex-cjk-all"
+          for attempt in 1 2 3; do
+            timeout 9m sudo bash -c "apt-get -qq update && apt-get install -y $pkgs" && break
+            if [ "$attempt" = 3 ]; then echo "apt-get failed after 3 attempts"; exit 1; fi
+            echo "apt-get attempt $attempt failed; retrying in 30s"; sleep 30
+          done
       - name: Build HTML
         shell: bash -l {0}
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,22 +20,24 @@ jobs:
       - name: Graphics Support #TODO: Review if graphviz is needed
         timeout-minutes: 10
         run: |
-          # Retried with a per-attempt timeout: a stalled Ubuntu mirror otherwise
+          # Retried with per-command timeouts (timeout inside sudo, so the kill reaches
+          # apt-get and the dpkg lock is released): a stalled Ubuntu mirror otherwise
           # hangs this step for hours (two 358-minute hangs on 2026-08-18).
           pkgs="graphviz"
           for attempt in 1 2; do
-            timeout 4m sudo bash -c "apt-get -qq update && apt-get install -y $pkgs" && break
+            sudo timeout -k 30s 1m apt-get -qq update && sudo timeout -k 30s 3m apt-get install -y $pkgs && break
             if [ "$attempt" = 2 ]; then echo "apt-get failed after 2 attempts"; exit 1; fi
             echo "apt-get attempt $attempt failed; retrying in 30s"; sleep 30
           done
       - name: Install latex dependencies
         timeout-minutes: 30
         run: |
-          # Retried with a per-attempt timeout: a stalled Ubuntu mirror otherwise
+          # Retried with per-command timeouts (timeout inside sudo, so the kill reaches
+          # apt-get and the dpkg lock is released): a stalled Ubuntu mirror otherwise
           # hangs this step for hours (two 358-minute hangs on 2026-08-18).
           pkgs="texlive-latex-recommended texlive-latex-extra texlive-fonts-recommended texlive-fonts-extra texlive-xetex latexmk xindy dvipng cm-super latex-cjk-all"
           for attempt in 1 2; do
-            timeout 14m sudo bash -c "apt-get -qq update && apt-get install -y $pkgs" && break
+            sudo timeout -k 30s 2m apt-get -qq update && sudo timeout -k 30s 12m apt-get install -y $pkgs && break
             if [ "$attempt" = 2 ]; then echo "apt-get failed after 2 attempts"; exit 1; fi
             echo "apt-get attempt $attempt failed; retrying in 30s"; sleep 30
           done

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,22 +18,27 @@ jobs:
           environment-file: environment.yml
           activate-environment: quantecon
       - name: Graphics Support #TODO: Review if graphviz is needed
+        timeout-minutes: 10
         run: |
-          sudo apt-get -qq update && sudo apt-get install -y graphviz
+          # Retried with a per-attempt timeout: a stalled Ubuntu mirror otherwise
+          # hangs this step for hours (two 358-minute hangs on 2026-08-18).
+          pkgs="graphviz"
+          for attempt in 1 2 3; do
+            timeout 3m sudo bash -c "apt-get -qq update && apt-get install -y $pkgs" && break
+            if [ "$attempt" = 3 ]; then echo "apt-get failed after 3 attempts"; exit 1; fi
+            echo "apt-get attempt $attempt failed; retrying in 30s"; sleep 30
+          done
       - name: Install latex dependencies
+        timeout-minutes: 30
         run: |
-          sudo apt-get -qq update
-          sudo apt-get install -y     \
-            texlive-latex-recommended \
-            texlive-latex-extra       \
-            texlive-fonts-recommended \
-            texlive-fonts-extra       \
-            texlive-xetex             \
-            latexmk                   \
-            xindy                     \
-            dvipng                    \
-            cm-super                  \
-            latex-cjk-all
+          # Retried with a per-attempt timeout: a stalled Ubuntu mirror otherwise
+          # hangs this step for hours (two 358-minute hangs on 2026-08-18).
+          pkgs="texlive-latex-recommended texlive-latex-extra texlive-fonts-recommended texlive-fonts-extra texlive-xetex latexmk xindy dvipng cm-super latex-cjk-all"
+          for attempt in 1 2 3; do
+            timeout 9m sudo bash -c "apt-get -qq update && apt-get install -y $pkgs" && break
+            if [ "$attempt" = 3 ]; then echo "apt-get failed after 3 attempts"; exit 1; fi
+            echo "apt-get attempt $attempt failed; retrying in 30s"; sleep 30
+          done
       - name: Display Conda Environment Versions
         shell: bash -l {0}
         run: conda list

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,9 +23,9 @@ jobs:
           # Retried with a per-attempt timeout: a stalled Ubuntu mirror otherwise
           # hangs this step for hours (two 358-minute hangs on 2026-08-18).
           pkgs="graphviz"
-          for attempt in 1 2 3; do
-            timeout 3m sudo bash -c "apt-get -qq update && apt-get install -y $pkgs" && break
-            if [ "$attempt" = 3 ]; then echo "apt-get failed after 3 attempts"; exit 1; fi
+          for attempt in 1 2; do
+            timeout 4m sudo bash -c "apt-get -qq update && apt-get install -y $pkgs" && break
+            if [ "$attempt" = 2 ]; then echo "apt-get failed after 2 attempts"; exit 1; fi
             echo "apt-get attempt $attempt failed; retrying in 30s"; sleep 30
           done
       - name: Install latex dependencies
@@ -34,9 +34,9 @@ jobs:
           # Retried with a per-attempt timeout: a stalled Ubuntu mirror otherwise
           # hangs this step for hours (two 358-minute hangs on 2026-08-18).
           pkgs="texlive-latex-recommended texlive-latex-extra texlive-fonts-recommended texlive-fonts-extra texlive-xetex latexmk xindy dvipng cm-super latex-cjk-all"
-          for attempt in 1 2 3; do
-            timeout 9m sudo bash -c "apt-get -qq update && apt-get install -y $pkgs" && break
-            if [ "$attempt" = 3 ]; then echo "apt-get failed after 3 attempts"; exit 1; fi
+          for attempt in 1 2; do
+            timeout 14m sudo bash -c "apt-get -qq update && apt-get install -y $pkgs" && break
+            if [ "$attempt" = 2 ]; then echo "apt-get failed after 2 attempts"; exit 1; fi
             echo "apt-get attempt $attempt failed; retrying in 30s"; sleep 30
           done
       - name: Display Conda Environment Versions

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,18 +22,16 @@ jobs:
           environment-file: environment.yml
           activate-environment: quantecon
       - name: Install latex dependencies
+        timeout-minutes: 30
         run: |
-          sudo apt-get -qq update
-          sudo apt-get install -y     \
-            texlive-latex-recommended \
-            texlive-latex-extra       \
-            texlive-fonts-recommended \
-            texlive-fonts-extra       \
-            texlive-xetex             \
-            latexmk                   \
-            xindy                     \
-            dvipng                    \
-            cm-super
+          # Retried with a per-attempt timeout: a stalled Ubuntu mirror otherwise
+          # hangs this step for hours (two 358-minute hangs on 2026-08-18).
+          pkgs="texlive-latex-recommended texlive-latex-extra texlive-fonts-recommended texlive-fonts-extra texlive-xetex latexmk xindy dvipng cm-super"
+          for attempt in 1 2 3; do
+            timeout 9m sudo bash -c "apt-get -qq update && apt-get install -y $pkgs" && break
+            if [ "$attempt" = 3 ]; then echo "apt-get failed after 3 attempts"; exit 1; fi
+            echo "apt-get attempt $attempt failed; retrying in 30s"; sleep 30
+          done
       - name: Display Conda Environment Versions
         shell: bash -l {0}
         run: conda list

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,11 +24,12 @@ jobs:
       - name: Install latex dependencies
         timeout-minutes: 30
         run: |
-          # Retried with a per-attempt timeout: a stalled Ubuntu mirror otherwise
+          # Retried with per-command timeouts (timeout inside sudo, so the kill reaches
+          # apt-get and the dpkg lock is released): a stalled Ubuntu mirror otherwise
           # hangs this step for hours (two 358-minute hangs on 2026-08-18).
           pkgs="texlive-latex-recommended texlive-latex-extra texlive-fonts-recommended texlive-fonts-extra texlive-xetex latexmk xindy dvipng cm-super"
           for attempt in 1 2; do
-            timeout 14m sudo bash -c "apt-get -qq update && apt-get install -y $pkgs" && break
+            sudo timeout -k 30s 2m apt-get -qq update && sudo timeout -k 30s 12m apt-get install -y $pkgs && break
             if [ "$attempt" = 2 ]; then echo "apt-get failed after 2 attempts"; exit 1; fi
             echo "apt-get attempt $attempt failed; retrying in 30s"; sleep 30
           done

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,9 +27,9 @@ jobs:
           # Retried with a per-attempt timeout: a stalled Ubuntu mirror otherwise
           # hangs this step for hours (two 358-minute hangs on 2026-08-18).
           pkgs="texlive-latex-recommended texlive-latex-extra texlive-fonts-recommended texlive-fonts-extra texlive-xetex latexmk xindy dvipng cm-super"
-          for attempt in 1 2 3; do
-            timeout 9m sudo bash -c "apt-get -qq update && apt-get install -y $pkgs" && break
-            if [ "$attempt" = 3 ]; then echo "apt-get failed after 3 attempts"; exit 1; fi
+          for attempt in 1 2; do
+            timeout 14m sudo bash -c "apt-get -qq update && apt-get install -y $pkgs" && break
+            if [ "$attempt" = 2 ]; then echo "apt-get failed after 2 attempts"; exit 1; fi
             echo "apt-get attempt $attempt failed; retrying in 30s"; sleep 30
           done
       - name: Display Conda Environment Versions


### PR DESCRIPTION
Bare `sudo apt-get install -y` with no `timeout-minutes` and no retry lets a stalled Ubuntu mirror hang CI for hours: two **358-minute** hangs on 2026-08-18 across two edition repos ten minutes apart (a mirror outage), four more hangs on 2026-08-19 (`Install latex dependencies` 77/15/16 min, `Graphics Support` 21 min) each cleared only by cancel-and-rerun, and a 59-minute slow-but-green install on 2026-08-20.

This PR hardens every apt-installing step in the workflows that carry one (`ci.yml`, `cache.yml`, `publish.yml` where present):

- a step-level `timeout-minutes` (10 for graphviz, 30 for the texlive set), so a hang can no longer take the six-hour job limit;
- up to three attempts with a per-attempt `timeout` (3m / 9m) and a 30-second pause, so a transient mirror outage is ridden out rather than failing the build — a timeout alone would only turn a six-hour hang into a fast red build.

Package lists are unchanged. The apt steps are edition-local (the shared `QuantEcon/actions/templates` carry none), so this lands per repo. Part of the five-repo sweep tracked in QuantEcon/project-translation#43.
