### PR TITLE
Remove the stale duplicated frontmatter block from hoist_failure.md

### DIFF
--- a/lectures/hoist_failure.md
+++ b/lectures/hoist_failure.md
@@ -31,31 +31,6 @@ translation:
     Exercises: 练习
 ---
 
-jupytext:
-  text_representation:
-    extension: .md
-    format_name: myst
-    format_version: 0.13
-    jupytext_version: 1.10.3
-kernelspec:
-  display_name: Python 3
-  language: python
-  name: python3
-translation:
-  title: 故障树不确定性
-  headings:
-    Overview: 概述
-    The lognormal distribution: 对数正态分布
-    The convolution theorem: 卷积定理
-    Approximating continuous distributions: 近似连续分布
-    Discretizing the lognormal distribution: 离散化对数正态分布
-    Convolving probability mass functions: 概率质量函数的卷积
-    Fault tree analysis: 故障树分析
-    Failure rates unknown: 未知的故障率
-    Application: waste hoist failure rate: 应用：废物提升机失效率
-    Exercises: 练习
----
-
 ```{raw} jupyter
 <div id="qe-notebook-header" align="right" style="text-align:right;">
         <a href="https://quantecon.org/" title="quantecon.org">


### PR DESCRIPTION
The strict cache build ([run 32426519586](https://github.com/QuantEcon/lecture-python.zh-cn/actions/runs/32426519586)) executed every notebook — including `learning_approximation` after #262 — and then failed on a single `-W` warning: `hoist_failure.md:34: Document headings start at H2, not H1`.

Cause: the #260 resync left the **previous frontmatter body** in place below the new frontmatter (lines 32–58 on `main`: a bare `jupytext:` … `translation:` block closed by `---`), so Sphinx sees leading content ahead of the `{raw}` header and the H1. The preview build on #260 tolerated it as a warning, which is the same preview-vs-strict-build gap that let the `_fonts/` path through.

This removes only the duplicated 25-line block; the engine's frontmatter (which carries the fuller nested heading map) and the lecture body are untouched. Once merged, a cache run should go green and the publish tag can follow with `mccall_risk` (#264) included.

This is a second instance of an engine resync shipping an embedded-frontmatter defect; noted for QuantEcon/action-translation (the `forward` path has an embedded-frontmatter check, so the question is why it did not fire here).