### PR TITLE
Renumber Job Search VI-X, and point baseurl at the live site

### DIFF
--- a/lectures/_config.yml
+++ b/lectures/_config.yml
@@ -25,7 +25,7 @@ bibtex_bibfiles:
    - _static/quant-econ.bib
 
 html:
-  baseurl: https://python.quantecon-zh-cn.org/
+  baseurl: https://quantecon.github.io/lecture-python.zh-cn/
 
 latex:
    latex_documents:

--- a/lectures/career.md
+++ b/lectures/career.md
@@ -8,7 +8,7 @@ kernelspec:
   language: python
   name: python3
 translation:
-  title: 工作搜寻 VI：职业选择建模
+  title: 工作搜寻 VII：职业选择建模
   headings:
     Overview: 概述
     Overview::Model Features: 模型特点
@@ -27,7 +27,7 @@ translation:
 </div>
 ```
 
-# 工作搜寻 VI：职业选择建模
+# 工作搜寻 VII：职业选择建模
 
 ```{index} single: Modeling; Career Choice
 ```

--- a/lectures/jv.md
+++ b/lectures/jv.md
@@ -8,7 +8,7 @@ kernelspec:
   language: python
   name: python3
 translation:
-  title: 工作搜寻 VII：在职搜索
+  title: 工作搜寻 VIII：在职搜索
   headings:
     Overview: 概述
     Overview::Model Features: 模型特点
@@ -29,7 +29,7 @@ translation:
 </div>
 ```
 
-# {index}`工作搜寻 VII：在职搜索 <single: Job Search VII: On-the-Job Search>`
+# {index}`工作搜寻 VIII：在职搜索 <single: Job Search VIII: On-the-Job Search>`
 
 ```{index} single: Models; On-the-Job Search
 ```

--- a/lectures/mccall_persist_trans.md
+++ b/lectures/mccall_persist_trans.md
@@ -10,7 +10,7 @@ kernelspec:
   language: python
   name: python3
 translation:
-  title: 工作搜寻 V：持续性与暂时性工资冲击
+  title: 工作搜寻 VI：持续性与暂时性工资冲击
   headings:
     Overview: 概述
     The model: 模型
@@ -28,7 +28,7 @@ translation:
 </div>
 ```
 
-# 工作搜寻 V：持续性与暂时性工资冲击
+# 工作搜寻 VI：持续性与暂时性工资冲击
 
 ```{include} _admonition/gpu.md
 ```

--- a/lectures/mccall_q.md
+++ b/lectures/mccall_q.md
@@ -10,7 +10,7 @@ kernelspec:
   language: python
   name: python3
 translation:
-  title: 工作搜寻 IX：McCall劳动者的Q学习
+  title: 工作搜寻 X：McCall劳动者的Q学习
   headings:
     Overview: 概述
     Review of McCall model: McCall 模型回顾
@@ -21,7 +21,7 @@ translation:
     Possible extensions: 可能的扩展方向
 ---
 
-# 工作搜寻 IX：McCall劳动者的Q学习
+# 工作搜寻 X：McCall劳动者的Q学习
 
 ## 概述
 

--- a/lectures/odu.md
+++ b/lectures/odu.md
@@ -8,7 +8,7 @@ kernelspec:
   language: python
   name: python3
 translation:
-  title: '工作搜寻 VIII: 带学习的搜索'
+  title: '工作搜寻 IX: 带学习的搜索'
   headings:
     Overview: 概述
     Overview::Model Features: 模型特点
@@ -43,7 +43,7 @@ translation:
 </div>
 ```
 
-# 工作搜寻 VIII: 带学习的搜索
+# 工作搜寻 IX: 带学习的搜索
 
 ```{contents} 目录
 :depth: 2


### PR DESCRIPTION
Two independent fixes, bundled because each takes effect only at the next publish build and that build is imminent — the re-publish that #270 requires. Splitting them would cost a second full CI render for one changed line.

## 1. Job Search renumbering — refs #266

Upstream inserted *Job Search V* and shifted five siblings. Those shifts were in the auto-closed #242 and never arrived by another route, so seeding `mccall_risk` as V in #264 turned a latent gap into an active collision: `mccall_risk` and `mccall_persist_trans` both read 工作搜寻 **V**, and everything after ran one behind.

Each numeral now matches the English source verbatim, checked file by file against `QuantEcon/lecture-python.myst`:

| Lecture | Before | After | English source |
|---|---|---|---|
| `mccall_persist_trans` | V | **VI** | Job Search VI |
| `career` | VI | **VII** | Job Search VII |
| `jv` | VII | **VIII** | Job Search VIII |
| `odu` | VIII | **IX** | Job Search IX |
| `mccall_q` | IX | **X** | Job Search X |

Eleven lines in five files: each lecture's `# ` heading and its `translation.title`, plus the English half of `jv`'s `{index}` target, which also read VII and would otherwise have left the index entry pointing at the old numeral.

**Job Search I–IV are deliberately untouched.** They sit before the insertion point, so the two in-prose cross-references in `mccall_persist_trans` — to 工作搜寻 III and 工作搜寻 IV — are still correct and were left alone. After this change the series reads I through X with no duplicate and no gap; a full-corpus sweep for `工作搜寻 <numeral>` and `Job Search <numeral>` confirms it.

This is only a partial delivery of #266 (issue deliberately left open), which also carries the two refactor backports (`ak_aiyagari` from myst#706, `harrison_kreps` from myst#669) and the `likelihood_bayes` state-file refresh. Those touch code cells, so they belong in their own change with its own execution run.

## 2. Baseurl — refs QuantEcon/project-translation#20

`lectures/_config.yml` set `html.baseurl` to `python.quantecon-zh-cn.org`, which is **NXDOMAIN**; `gh api repos/QuantEcon/lecture-python.zh-cn/pages` returns `cname: null`, so no custom domain has ever been configured. The site serves from `quantecon.github.io/lecture-python.zh-cn`.

It reached published output only through two `<head>` tags — `rel=canonical` and `og:url` — 296 of them across 148 of the 159 published HTML files. No reader was ever affected: navigation, assets and inter-lecture links are all relative or point at live hosts. What it did was tell every search engine that those 148 pages authoritatively live on a host with no DNS record. The other five editions already point at their `quantecon.github.io` URL; this brings the sixth into line, per the ruling on that issue.

The line dates to `387e084`, 2025-01-15 — not a regression, just never noticed.

## Scope and risk

Prose and configuration only. No code cell changes, so the execution cache is untouched and this needs no new cache run to publish correctly — only the HTML rebuild that a publish does anyway.

## What this does and does not fix on the live site

The two lectures currently share **both** a Roman numeral and a chapter number, from unrelated causes. This PR fixes the numeral. The duplicated chapter number `57.` is the stale Sphinx environment in #270, fixed by #272. Both must land before the re-publish for those pages to read correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

