### PR TITLE
Register the CJK font in util_rand_resp — five figures render Chinese as tofu

### DIFF
--- a/lectures/util_rand_resp.md
+++ b/lectures/util_rand_resp.md
@@ -50,6 +50,11 @@ Lars Ljungqvist {cite}`ljungqvist1993unified` 分析了受访者是否如实回�
 
 ```{code-cell} ipython3
 import matplotlib.pyplot as plt
+import matplotlib as mpl
+FONTPATH = "fonts/SourceHanSerifSC-SemiBold.otf"
+mpl.font_manager.fontManager.addfont(FONTPATH)
+plt.rcParams['font.family'] = ['Source Han Serif SC', 'DejaVu Sans']
+
 import numpy as np
 ```
 


### PR DESCRIPTION
Fixes tofu on five figures in `util_rand_resp`, live on the site since `publish-2026aug24b`.

## What is wrong

The lecture draws five figures whose labels, legends and annotations are Chinese — 真话边界, 诚实回答, 说谎, 等方差曲线, 最优设计 — but it is one of 36 lectures carrying no i18n font registration. matplotlib therefore falls back to DejaVu Sans, which has no CJK glyphs, and the characters render as boxes.

`bin/check-tofu --site` on the republished site reports it as the only affected page of 145:

    util_rand_resp
        characters lost: 优回实差方曲最界真等答线计设诚话说谎边
        Glyph 20248 (\N{CJK UNIFIED IDEOGRAPH-4F18}) missing from font(s) DejaVu Sans

## Why it appeared now, and why that is reassuring rather than alarming

The lecture text did not change. Comparing the two release tarballs directly: `publish-2026aug24`'s `util_rand_resp.html` contains **0** occurrences of `missing from font`, and `publish-2026aug24b`'s contains **19**. Both render 7 images.

The difference is which execution produced the figures. The earlier release drew them from the 2026-08-17 cache artifact; that artifact's environment happened to resolve a CJK-capable face without the lecture asking for one. The 2026-08-24 cache run executed the lecture afresh and did not. So the defect was **latent, not new** — the lecture has been one environment change away from this for as long as it has had Chinese labels, and a re-execution finally exposed it.

This is worth stating plainly because it means the earlier "clean" `check-tofu` result was luck, not correctness.

## The fix

The same block `career.md` uses, which publishes Chinese figures correctly. The `DejaVu Sans` fallback is retained deliberately: this lecture mixes Chinese labels with LaTeX math and Latin axis text (`Pr(A|yes)`), so a fallback is worth having.

## Scope

Of the 36 lectures with no font registration, `util_rand_resp` is the **only** one with Chinese inside plotting calls. The other 35 are latent in the same way and would break identically the day a label is translated. Making the registration unconditional across the corpus — or emitting it from the engine — is the durable answer and is not attempted here.

This touches a code cell, so the lecture re-executes at the next build rather than coming from cache. That is one lecture's execution, not a full run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
